### PR TITLE
Profiling timings for GetFrontPageDataWithTags

### DIFF
--- a/MonkeyWrench.Web.UI/index.aspx.cs
+++ b/MonkeyWrench.Web.UI/index.aspx.cs
@@ -20,6 +20,7 @@ using System.Web.UI.WebControls;
 using MonkeyWrench.DataClasses;
 using MonkeyWrench.DataClasses.Logic;
 using MonkeyWrench.Web.WebServices;
+using MonkeyWrench;
 
 public partial class index : System.Web.UI.Page
 {
@@ -35,74 +36,78 @@ public partial class index : System.Web.UI.Page
 		base.OnLoad (e);
 
 		try {
-			FrontPageResponse data;
+			using(new ProfTimer("Home")) {
+				FrontPageResponse data;
 
-			if (string.IsNullOrEmpty (Request ["limit"])) {
-				if (Request.Cookies ["limit"] != null)
-					int.TryParse (Request.Cookies ["limit"].Value, out limit);
-			} else {
-				int.TryParse (Request ["limit"], out limit);
-			}
-			if (limit <= 0)
-				limit = 10;
-			Response.Cookies.Add (new HttpCookie ("limit", limit.ToString ()));
-
-			string lanes_str = null;
-			string lane_ids_str = null;
-
-			string [] lanes = null;
-			List<int> lane_ids = null;
-			string [] tags = null;
-
-			if (!string.IsNullOrEmpty (Request ["show_all"])) {
-				// do nothing, default is to show all
-			} else if (!string.IsNullOrEmpty (Request ["tags"])) {
-				tags = Request ["tags"].Split (',');
-			} else {
-				HttpCookie cookie;
-
-				lanes_str = Request ["lane"];
-				lane_ids_str = Request ["lane_id"];
-
-				if (string.IsNullOrEmpty (lanes_str) && string.IsNullOrEmpty (lane_ids_str)) {
-					if ((cookie = Request.Cookies ["index:lane"]) != null) {
-						lanes_str = HttpUtility.UrlDecode (cookie.Value);
-					}
-					if ((cookie = Request.Cookies ["index:lane_id"]) != null) {
-						lane_ids_str = HttpUtility.UrlDecode (cookie.Value);
-					}
+				if (string.IsNullOrEmpty (Request ["limit"])) {
+					if (Request.Cookies ["limit"] != null)
+						int.TryParse (Request.Cookies ["limit"].Value, out limit);
+				} else {
+					int.TryParse (Request ["limit"], out limit);
 				}
+				if (limit <= 0)
+					limit = 10;
+				Response.Cookies.Add (new HttpCookie ("limit", limit.ToString ()));
 
-				if (!string.IsNullOrEmpty (lanes_str))
-					lanes = lanes_str.Split (';');
-				if (!string.IsNullOrEmpty (lane_ids_str)) {
-					lane_ids = new List<int> ();
-					foreach (string str in lane_ids_str.Split (';')) {
-						int? ii = Utils.TryParseInt32 (str);
-						if (ii.HasValue)
-							lane_ids.Add (ii.Value);
+				string lanes_str = null;
+				string lane_ids_str = null;
+
+				string [] lanes = null;
+				List<int> lane_ids = null;
+				string [] tags = null;
+
+				if (!string.IsNullOrEmpty (Request ["show_all"])) {
+					// do nothing, default is to show all
+				} else if (!string.IsNullOrEmpty (Request ["tags"])) {
+					tags = Request ["tags"].Split (',');
+				} else {
+					HttpCookie cookie;
+
+					lanes_str = Request ["lane"];
+					lane_ids_str = Request ["lane_id"];
+
+					if (string.IsNullOrEmpty (lanes_str) && string.IsNullOrEmpty (lane_ids_str)) {
+						if ((cookie = Request.Cookies ["index:lane"]) != null) {
+							lanes_str = HttpUtility.UrlDecode (cookie.Value);
+						}
+						if ((cookie = Request.Cookies ["index:lane_id"]) != null) {
+							lane_ids_str = HttpUtility.UrlDecode (cookie.Value);
+						}
 					}
+
+					if (!string.IsNullOrEmpty (lanes_str))
+						lanes = lanes_str.Split (';');
+					if (!string.IsNullOrEmpty (lane_ids_str)) {
+						lane_ids = new List<int> ();
+						foreach (string str in lane_ids_str.Split (';')) {
+							int? ii = Utils.TryParseInt32 (str);
+							if (ii.HasValue)
+								lane_ids.Add (ii.Value);
+						}
+					}
+
+					Response.Cookies.Set (new HttpCookie ("index:lane", HttpUtility.UrlEncode (lanes_str)));
+					Response.Cookies.Set (new HttpCookie ("index:lane_id", HttpUtility.UrlEncode (lane_ids_str)));
 				}
-
-				Response.Cookies.Set (new HttpCookie ("index:lane", HttpUtility.UrlEncode (lanes_str)));
-				Response.Cookies.Set (new HttpCookie ("index:lane_id", HttpUtility.UrlEncode (lane_ids_str)));
-			}
-
-			data = Master.WebService.GetFrontPageDataWithTags (Master.WebServiceLogin, limit, 0, lanes, lane_ids != null ? lane_ids.ToArray () : null, 30, tags);
-
-			if (data.Exception != null) {
-				if (data.Exception.HttpCode == 403) {
-					Master.RequestLogin ();
+				
+				using(new ProfTimer("index.OnLoad GetFrontPageDataWithTags call")) {
+					data = Master.WebService.GetFrontPageDataWithTags (Master.WebServiceLogin, limit, 0, lanes, lane_ids != null ? lane_ids.ToArray () : null, 30, tags);
+				}
+				if (data.Exception != null) {
+					if (data.Exception.HttpCode == 403) {
+						Master.RequestLogin ();
+						return;
+					}
+					lblMessage.Text = data.Exception.Message;
+					MonkeyWrench.Logger.Log ("index.aspx exception: {0}", data.Exception.AsString);
 					return;
 				}
-				lblMessage.Text = data.Exception.Message;
-				MonkeyWrench.Logger.Log ("index.aspx exception: {0}", data.Exception.AsString);
-				return;
-			}
 
-			this.buildtable.InnerHtml = tags != null ? GenerateTaggedOverview (data) : GenerateOverview (data);
+				this.buildtable.InnerHtml = tags != null ? GenerateTaggedOverview (data) : GenerateOverview (data);
+			}
 		} catch (Exception ex) {
 			lblMessage.Text = Utils.FormatException (ex, true);
+			throw;
 		}
 	}
 

--- a/MonkeyWrench/MonkeyWrench.csproj
+++ b/MonkeyWrench/MonkeyWrench.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{EBFBC3BF-10E1-4482-B9BE-A516934C099A}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -54,9 +54,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
+    <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -79,6 +77,7 @@
     <Compile Include="ProcessHelperWindows.cs" />
     <Compile Include="ProcessReader.cs" />
     <Compile Include="SynchronizedStreamWriter.cs" />
+    <Compile Include="ProfTimer.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/MonkeyWrench/ProfTimer.cs
+++ b/MonkeyWrench/ProfTimer.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace MonkeyWrench
+{
+	public class ProfTimer : IDisposable
+	{
+		private readonly string name;
+		private Stopwatch watch;
+
+		public ProfTimer (string name)
+		{
+			this.name = name;
+			watch = new Stopwatch ();
+			watch.Start ();
+		}
+
+		#region IDisposable implementation
+
+		public void Dispose ()
+		{
+			watch.Stop ();
+			Logger.Log ("TIMER: {0} - {1} ms", name, watch.ElapsedMilliseconds);
+		}
+
+		#endregion
+	}
+}
+


### PR DESCRIPTION
This adds some profile timers for GetFrontPageDataWithTags, which record how long it takes for various parts of the function to execute in production so that we can optimize them.

(Note: I don't recommend actually merging this into master, since this is intended to be a temporary modification for measuring performance)

Now without my other changes.