### PR TITLE
Speed up the front page by bypassing SOAP in using WebServices

### DIFF
--- a/MonkeyWrench.Web.UI/Code/Utils.cs
+++ b/MonkeyWrench.Web.UI/Code/Utils.cs
@@ -175,6 +175,18 @@ public static class Utils
 		}
 	}
 
+	public static MonkeyWrench.WebServices.WebServices local_web_service;
+
+	public static MonkeyWrench.WebServices.WebServices LocalWebService
+	{
+		get
+		{
+			if (local_web_service == null)
+				local_web_service = new MonkeyWrench.WebServices.WebServices (false);
+			return local_web_service;
+		}
+	}
+
 	public static int? TryParseInt32 (string input)
 	{
 		int i;

--- a/MonkeyWrench.Web.UI/MonkeyWrench.Web.UI.csproj
+++ b/MonkeyWrench.Web.UI/MonkeyWrench.Web.UI.csproj
@@ -381,6 +381,10 @@
       <Project>{EBFBC3BF-10E1-4482-B9BE-A516934C099A}</Project>
       <Name>MonkeyWrench</Name>
     </ProjectReference>
+    <ProjectReference Include="..\MonkeyWrench.Web.WebService\MonkeyWrench.Web.WebService.csproj">
+      <Project>{86D06788-14A7-4962-88F0-FB58B7D34FF1}</Project>
+      <Name>MonkeyWrench.Web.WebService</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <WebReferences Include="Web References\" />

--- a/MonkeyWrench.Web.UI/index.aspx.cs
+++ b/MonkeyWrench.Web.UI/index.aspx.cs
@@ -88,7 +88,7 @@ public partial class index : System.Web.UI.Page
 				Response.Cookies.Set (new HttpCookie ("index:lane_id", HttpUtility.UrlEncode (lane_ids_str)));
 			}
 
-			data = Master.WebService.GetFrontPageDataWithTags (Master.WebServiceLogin, limit, 0, lanes, lane_ids != null ? lane_ids.ToArray () : null, 30, tags);
+			data = Utils.LocalWebService.GetFrontPageDataWithTags (Master.WebServiceLogin, limit, 0, lanes, lane_ids != null ? lane_ids.ToArray () : null, 30, tags);
 
 			if (data.Exception != null) {
 				if (data.Exception.HttpCode == 403) {

--- a/MonkeyWrench.Web.WebService/WebServices.asmx.cs
+++ b/MonkeyWrench.Web.WebService/WebServices.asmx.cs
@@ -31,9 +31,13 @@ namespace MonkeyWrench.WebServices
 	[System.ComponentModel.ToolboxItem (false)]
 	public class WebServices : System.Web.Services.WebService
 	{
-		public WebServices ()
+		public WebServices () : this(true)
 		{
-			Configuration.LoadConfiguration (new string [] { });
+		}
+
+		public WebServices (bool loadConfig) {
+			if(loadConfig)
+				Configuration.LoadConfiguration (new string [] { });
 		}
 
 		internal void Authenticate (DB db, WebServiceLogin login, WebServiceResponse response)


### PR DESCRIPTION
The current flow of the index page is to call the function `WebServices.GetFrontPageDataWithTags`, which makes a SOAP request to the WebServices server (which, for private wrench, is the same as the Web UI server), which in turn queries the database and returns a response. After profiling, we have determined that making the SOAP request and [de]serializing the data to XML adds a ~200% overhead to the call to `WebServices.GetFrontPageDataWithTags`.

This patch changes the index page so that it creates a local version of the `WebServices` object, and uses that to directly return the results of `WebServices.GetFrontPageDataWithTags`, bypassing the SOAP interface entirely.

This requires that the Web UI server is configured with the database credentials (which is already the case if the same server is being used for both the UI and WebServices). It also bypasses the WebServices layer, which might have issues that I have missed.

@duncanmak has reviewed this patch.
