### PR TITLE
Better error handling in Web UI

### DIFF
--- a/MonkeyWrench.Web.UI/Admin.aspx.cs
+++ b/MonkeyWrench.Web.UI/Admin.aspx.cs
@@ -29,49 +29,37 @@ public partial class Admin : System.Web.UI.Page
 
 	protected void Page_Load (object sender, EventArgs e)
 	{
-		try {
-			GetAdminInfoResponse response;
-			string action = Request ["action"];
+		GetAdminInfoResponse response;
+		string action = Request ["action"];
 
-			if (!string.IsNullOrEmpty (action)) {
-				switch (action) {
-				case "schedule":
-					Master.WebService.ExecuteScheduler (Master.WebServiceLogin, true);
-					Response.Redirect (Request.UrlReferrer == null ? "index.aspx" : Request.UrlReferrer.ToString (), false);
-					return;
-				}
+		if (!string.IsNullOrEmpty (action)) {
+			switch (action) {
+			case "schedule":
+				Master.WebService.ExecuteScheduler (Master.WebServiceLogin, true);
+				Response.Redirect (Request.UrlReferrer == null ? "index.aspx" : Request.UrlReferrer.ToString (), false);
+				return;
 			}
-
-			response = Master.WebService.GetAdminInfo (Master.WebServiceLogin);
-
-			lblDeletionDirectiveStatus.Text = response.IsDeletionDirectivesExecuting ? "Running" : "Not running";
-			lblSchedulerStatus.Text = response.IsSchedulerExecuting ? "Running" : "Not running";
-		} catch (Exception ex) {
-			lblMessage.Text = Utils.FormatException (ex);
 		}
+
+		response = Master.WebService.GetAdminInfo (Master.WebServiceLogin);
+
+		lblDeletionDirectiveStatus.Text = response.IsDeletionDirectivesExecuting ? "Running" : "Not running";
+		lblSchedulerStatus.Text = response.IsSchedulerExecuting ? "Running" : "Not running";
 	}
 
 	protected void cmdSchedule_Click (object sender, EventArgs e)
 	{
-		try {
-			cmdSchedule.Enabled = false;
-			Master.WebService.ExecuteScheduler (Master.WebServiceLogin, true);
-			lblSchedule.Text = "Scheduler started. It's run asynchronously, so no updates will be shown here.";
-			lblSchedulerStatus.Text = "Running";
-		} catch (Exception ex) {
-			lblSchedule.Text = Utils.FormatException (ex.Message);
-		}
+		cmdSchedule.Enabled = false;
+		Master.WebService.ExecuteScheduler (Master.WebServiceLogin, true);
+		lblSchedule.Text = "Scheduler started. It's run asynchronously, so no updates will be shown here.";
+		lblSchedulerStatus.Text = "Running";
 	}
 
 	protected void cmdExecuteDeletionDirectives_Click (object sender, EventArgs e)
 	{
-		try {
-			cmdExecuteDeletionDirectives.Enabled = false;
-			Master.WebService.ExecuteDeletionDirectives (Master.WebServiceLogin);
-			lblExecuteDeletionDirectives.Text = "Retention directives executed. They are run asynchronously, so no updates will be shown here.";
-			lblDeletionDirectiveStatus.Text = "Running";
-		} catch (Exception ex) {
-			lblExecuteDeletionDirectives.Text = Utils.FormatException (ex.Message);
-		}
+		cmdExecuteDeletionDirectives.Enabled = false;
+		Master.WebService.ExecuteDeletionDirectives (Master.WebServiceLogin);
+		lblExecuteDeletionDirectives.Text = "Retention directives executed. They are run asynchronously, so no updates will be shown here.";
+		lblDeletionDirectiveStatus.Text = "Running";
 	}
 }

--- a/MonkeyWrench.Web.UI/BuildBotStatus.aspx.cs
+++ b/MonkeyWrench.Web.UI/BuildBotStatus.aspx.cs
@@ -36,65 +36,61 @@ public partial class BuildBotStatus : System.Web.UI.Page
 		GetBuildBotStatusResponse response;
 		string action;
 
-		try {
-			response = Master.WebService.GetBuildBotStatus (Master.WebServiceLogin);
+		response = Master.WebService.GetBuildBotStatus (Master.WebServiceLogin);
 
-			action = Request ["action"];
-			if (!string.IsNullOrEmpty (action)) {
-				switch (action) {
-				case "select-release": {
-					int release_id;
-					int host_id;
-					if (int.TryParse (Request ["release_id"], out release_id)) {
-						if (int.TryParse (Request ["host_id"], out host_id)) {
-							DBHost host = response.Hosts.Find ((v) => v.id == host_id);
-							if (host == null) {
-								lblMessage.Text = "Invalid host id";
-							} else {
-								host.release_id = release_id == 0 ? null : new int? (release_id);
-								Master.WebService.EditHost (Master.WebServiceLogin, host);
-								Response.Redirect ("BuildBotStatus.aspx", false);
-								return;
-							}
+		action = Request ["action"];
+		if (!string.IsNullOrEmpty (action)) {
+			switch (action) {
+			case "select-release": {
+				int release_id;
+				int host_id;
+				if (int.TryParse (Request ["release_id"], out release_id)) {
+					if (int.TryParse (Request ["host_id"], out host_id)) {
+						DBHost host = response.Hosts.Find ((v) => v.id == host_id);
+						if (host == null) {
+							lblMessage.Text = "Invalid host id";
 						} else {
-							lblMessage.Text = "Invalid host";
+							host.release_id = release_id == 0 ? null : new int? (release_id);
+							Master.WebService.EditHost (Master.WebServiceLogin, host);
+							Response.Redirect ("BuildBotStatus.aspx", false);
+							return;
 						}
 					} else {
-						lblMessage.Text = "Invalid release";
+						lblMessage.Text = "Invalid host";
 					}
+				} else {
+					lblMessage.Text = "Invalid release";
+				}
 
-					break;
-				}
-				}
+				break;
+			}
+			}
+		}
+
+		if (response.Exception != null) {
+			lblMessage.Text = response.Exception.Message;
+		} else {
+			Logger.Log ("...");
+			foreach (DBBuildBotStatus status in response.Status) {
+				DBHost host = response.Hosts.Find ((v) => v.id == status.host_id);
+				DBRelease configured_release = host.release_id.HasValue ? response.Releases.Find ((v) => v.id == host.release_id.Value) : null;
+				TableRow row = new TableRow ();
+				row.Cells.Add (Utils.CreateTableCell (host.host));
+				row.Cells.Add (Utils.CreateTableCell (status.version));
+				row.Cells.Add (Utils.CreateTableCell (status.report_date.ToString ("yyyy/MM/dd HH:mm:ss UTC")));
+				row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript: selectBuildBotRelease (\"{0}\", {1}, \"{2}\")'>{0}</a>", configured_release == null ? "Manual" : configured_release.version, host.id, tblReleases.ClientID)));
+				tblStatus.Rows.Add (row);
 			}
 
-			if (response.Exception != null) {
-				lblMessage.Text = response.Exception.Message;
-			} else {
-				Logger.Log ("...");
-				foreach (DBBuildBotStatus status in response.Status) {
-					DBHost host = response.Hosts.Find ((v) => v.id == status.host_id);
-					DBRelease configured_release = host.release_id.HasValue ? response.Releases.Find ((v) => v.id == host.release_id.Value) : null;
-					TableRow row = new TableRow ();
-					row.Cells.Add (Utils.CreateTableCell (host.host));
-					row.Cells.Add (Utils.CreateTableCell (status.version));
-					row.Cells.Add (Utils.CreateTableCell (status.report_date.ToString ("yyyy/MM/dd HH:mm:ss UTC")));
-					row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript: selectBuildBotRelease (\"{0}\", {1}, \"{2}\")'>{0}</a>", configured_release == null ? "Manual" : configured_release.version, host.id, tblReleases.ClientID)));
-					tblStatus.Rows.Add (row);
-				}
-
-				foreach (DBRelease release in response.Releases) {
-					TableRow row = new TableRow ();
-					row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript: executeBuildBotSelection ({0})'>Select</a>", release.id)));
-					row.Cells.Add (Utils.CreateTableCell (release.version));
-					row.Cells.Add (Utils.CreateTableCell (release.revision));
-					row.Cells.Add (Utils.CreateTableCell (release.description));
-					tblReleases.Rows.Add (row);
-				}
-				tblReleases.Attributes ["style"] = "display:none";
+			foreach (DBRelease release in response.Releases) {
+				TableRow row = new TableRow ();
+				row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript: executeBuildBotSelection ({0})'>Select</a>", release.id)));
+				row.Cells.Add (Utils.CreateTableCell (release.version));
+				row.Cells.Add (Utils.CreateTableCell (release.revision));
+				row.Cells.Add (Utils.CreateTableCell (release.description));
+				tblReleases.Rows.Add (row);
 			}
-		} catch (Exception ex) {
-			lblMessage.Text = Utils.FormatException (ex, true);
+			tblReleases.Attributes ["style"] = "display:none";
 		}
 	}
 }

--- a/MonkeyWrench.Web.UI/Code/Utils.cs
+++ b/MonkeyWrench.Web.UI/Code/Utils.cs
@@ -208,3 +208,18 @@ public static class Utils
 		return str.Replace ("\n", "<br/>\n").Replace (" ", "&nbsp;").Replace ("\t", "&nbsp;&nbsp;&nbsp;&nbsp;");
 	}
 }
+
+/**
+ * Class for exceptions thrown to signal invalid user input.
+ */
+class ValidationException : Exception {
+	public ValidationException (string message) : base (message)
+	{
+	}
+	
+
+	public ValidationException (System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base (info, context)
+	{
+	}
+	
+}

--- a/MonkeyWrench.Web.UI/Delete.aspx.cs
+++ b/MonkeyWrench.Web.UI/Delete.aspx.cs
@@ -22,113 +22,107 @@ public partial class Delete : System.Web.UI.Page
 
 	protected void Page_Load (object sender, EventArgs e)
 	{
-		try {
-			if (!IsPostBack && string.IsNullOrEmpty (txtReturnTo.Value) && Request.UrlReferrer != null)
-				txtReturnTo.Value = Request.UrlReferrer.ToString ();
+		if (!IsPostBack && string.IsNullOrEmpty (txtReturnTo.Value) && Request.UrlReferrer != null)
+			txtReturnTo.Value = Request.UrlReferrer.ToString ();
 
-			action = Request ["action"];
-			if (string.IsNullOrEmpty (action)) {
-				lblMessage.Text = "Nothing to ask?!?";
+		action = Request ["action"];
+		if (string.IsNullOrEmpty (action)) {
+			lblMessage.Text = "Nothing to ask?!?";
+			return;
+		}
+
+		switch (action) {
+		case "delete-lane": {
+			if (!int.TryParse (Request ["lane_id"], out lane_id)) {
+				lblMessage.Text = "You need to specify a lane to delete.";
 				return;
 			}
 
-			switch (action) {
-			case "delete-lane": {
-				if (!int.TryParse (Request ["lane_id"], out lane_id)) {
-					lblMessage.Text = "You need to specify a lane to delete.";
-					return;
-				}
+			var lane = Master.WebService.FindLaneWithDependencies (Master.WebServiceLogin, lane_id, null);
+			var text = new System.Text.StringBuilder ();
 
-				var lane = Master.WebService.FindLaneWithDependencies (Master.WebServiceLogin, lane_id, null);
-				var text = new System.Text.StringBuilder ();
-
-				text.AppendFormat ("Are you sure you want to delete the lane '{0}' (ID: {1}) Count: {2}?<br/>", lane.lane.lane, lane.lane.id, lane.dependencies == null ? "N/A" : lane.dependencies.Count.ToString ());
-				if (lane.dependencies != null && lane.dependencies.Count > 0) {
-					text.AppendFormat ("<br/>There are {0} other lane(s) depending on this lane:<br/>", lane.dependencies.Count);
-					foreach (var dl in lane.dependencies) {
-						text.AppendFormat ("<a href=EditLane.aspx?lane_id={0}>{1}</a><br/>", dl.id, dl.lane);
-					}
-					text.AppendFormat ("<br/>These dependencies will also be removed.<br/>");
+			text.AppendFormat ("Are you sure you want to delete the lane '{0}' (ID: {1}) Count: {2}?<br/>", lane.lane.lane, lane.lane.id, lane.dependencies == null ? "N/A" : lane.dependencies.Count.ToString ());
+			if (lane.dependencies != null && lane.dependencies.Count > 0) {
+				text.AppendFormat ("<br/>There are {0} other lane(s) depending on this lane:<br/>", lane.dependencies.Count);
+				foreach (var dl in lane.dependencies) {
+					text.AppendFormat ("<a href=EditLane.aspx?lane_id={0}>{1}</a><br/>", dl.id, dl.lane);
 				}
-				lblMessage.Text = text.ToString ();
-				cmdConfirm.Enabled = true;
-				break;
+				text.AppendFormat ("<br/>These dependencies will also be removed.<br/>");
 			}
-			case "delete-host": {
-				if (!int.TryParse (Request ["host_id"], out host_id)) {
-					lblMessage.Text = "You need to specify a host to delete.";
-					return;
-				}
-
-				FindHostResponse host = Master.WebService.FindHost (Master.WebServiceLogin, host_id, null);
-
-				lblMessage.Text = string.Format ("Are you sure you want to delete the host '{0}' (ID: {1})?", host.Host.host, host.Host.id);
-				cmdConfirm.Enabled = true;
-				break;
+			lblMessage.Text = text.ToString ();
+			cmdConfirm.Enabled = true;
+			break;
+		}
+		case "delete-host": {
+			if (!int.TryParse (Request ["host_id"], out host_id)) {
+				lblMessage.Text = "You need to specify a host to delete.";
+				return;
 			}
-			case "delete-all-work-for-host": {
-				if (!int.TryParse (Request ["host_id"], out host_id)) {
-					lblMessage.Text = "You need to specify a host whose work should be deleted.";
-					return;
-				}
-				FindHostResponse host = Master.WebService.FindHost (Master.WebServiceLogin, host_id, null);
 
-				lblMessage.Text = string.Format ("Are you sure you want to delete all the work for the host '{0}' (ID: {1})?", host.Host.host, host.Host.id);
-				cmdConfirm.Enabled = true;
-				break;
-			}
-			case "delete-all-work-for-lane": {
-				if (!int.TryParse (Request ["lane_id"], out lane_id)) {
-					lblMessage.Text = "You need to specify a lane whose work should be deleted.";
-					return;
-				}
-				FindLaneResponse lane = Master.WebService.FindLane (Master.WebServiceLogin, lane_id, null);
+			FindHostResponse host = Master.WebService.FindHost (Master.WebServiceLogin, host_id, null);
 
-				lblMessage.Text = string.Format ("Are you sure you want to delete all the work for the lane '{0}' (ID: {1})?", lane.lane.lane, lane.lane.id);
-				cmdConfirm.Enabled = true;
-				break;
-				}
-			case "delete-all-revisions-for-lane": {
-				if (!int.TryParse (Request ["lane_id"], out lane_id)) {
-					lblMessage.Text = "You need to specify a lane whose revisions should be deleted.";
-					return;
-				}
-				FindLaneResponse lane = Master.WebService.FindLane (Master.WebServiceLogin, lane_id, null);
+			lblMessage.Text = string.Format ("Are you sure you want to delete the host '{0}' (ID: {1})?", host.Host.host, host.Host.id);
+			cmdConfirm.Enabled = true;
+			break;
+		}
+		case "delete-all-work-for-host": {
+			if (!int.TryParse (Request ["host_id"], out host_id)) {
+				lblMessage.Text = "You need to specify a host whose work should be deleted.";
+				return;
+			}
+			FindHostResponse host = Master.WebService.FindHost (Master.WebServiceLogin, host_id, null);
 
-				lblMessage.Text = string.Format ("Are you sure you want to delete all the revisions for the lane '{0}' (ID: {1})?", lane.lane.lane, lane.lane.id);
-				cmdConfirm.Enabled = true;
-				break;
+			lblMessage.Text = string.Format ("Are you sure you want to delete all the work for the host '{0}' (ID: {1})?", host.Host.host, host.Host.id);
+			cmdConfirm.Enabled = true;
+			break;
+		}
+		case "delete-all-work-for-lane": {
+			if (!int.TryParse (Request ["lane_id"], out lane_id)) {
+				lblMessage.Text = "You need to specify a lane whose work should be deleted.";
+				return;
 			}
-			case "clear-all-work-for-host": {
-				if (!int.TryParse (Request ["host_id"], out host_id)) {
-					lblMessage.Text = "You need to specify a host whose work should be cleared.";
-					return;
-				}
-				FindHostResponse host = Master.WebService.FindHost (Master.WebServiceLogin, host_id, null);
+			FindLaneResponse lane = Master.WebService.FindLane (Master.WebServiceLogin, lane_id, null);
 
-				lblMessage.Text = string.Format ("Are you sure you want to clear all the work for the host '{0}' (ID: {1})?", host.Host.host, host.Host.id);
-				cmdConfirm.Enabled = true;
-				break;
+			lblMessage.Text = string.Format ("Are you sure you want to delete all the work for the lane '{0}' (ID: {1})?", lane.lane.lane, lane.lane.id);
+			cmdConfirm.Enabled = true;
+			break;
 			}
-			case "clear-all-work-for-lane": {
-				if (!int.TryParse (Request ["lane_id"], out lane_id)) {
-					lblMessage.Text = "You need to specify a lane whose work should be cleared.";
-					return;
-				}
-				FindLaneResponse lane = Master.WebService.FindLane (Master.WebServiceLogin, lane_id, null);
+		case "delete-all-revisions-for-lane": {
+			if (!int.TryParse (Request ["lane_id"], out lane_id)) {
+				lblMessage.Text = "You need to specify a lane whose revisions should be deleted.";
+				return;
+			}
+			FindLaneResponse lane = Master.WebService.FindLane (Master.WebServiceLogin, lane_id, null);
 
-				lblMessage.Text = string.Format ("Are you sure you want to clear all the work for the lane '{0}' (ID: {1})?", lane.lane.lane, lane.lane.id);
-				cmdConfirm.Enabled = true;
-				break;
+			lblMessage.Text = string.Format ("Are you sure you want to delete all the revisions for the lane '{0}' (ID: {1})?", lane.lane.lane, lane.lane.id);
+			cmdConfirm.Enabled = true;
+			break;
+		}
+		case "clear-all-work-for-host": {
+			if (!int.TryParse (Request ["host_id"], out host_id)) {
+				lblMessage.Text = "You need to specify a host whose work should be cleared.";
+				return;
 			}
-			default:
-				lblMessage.Text = "Nothing to confirm. Click Cancel to go back.";
-				break;
+			FindHostResponse host = Master.WebService.FindHost (Master.WebServiceLogin, host_id, null);
+
+			lblMessage.Text = string.Format ("Are you sure you want to clear all the work for the host '{0}' (ID: {1})?", host.Host.host, host.Host.id);
+			cmdConfirm.Enabled = true;
+			break;
+		}
+		case "clear-all-work-for-lane": {
+			if (!int.TryParse (Request ["lane_id"], out lane_id)) {
+				lblMessage.Text = "You need to specify a lane whose work should be cleared.";
+				return;
 			}
-		} catch (Exception ex) {
-			cmdConfirm.Enabled = false;
-			cmdConfirm.Visible = false;
-			lblMessage.Text = Utils.FormatException (ex, true);
+			FindLaneResponse lane = Master.WebService.FindLane (Master.WebServiceLogin, lane_id, null);
+
+			lblMessage.Text = string.Format ("Are you sure you want to clear all the work for the lane '{0}' (ID: {1})?", lane.lane.lane, lane.lane.id);
+			cmdConfirm.Enabled = true;
+			break;
+		}
+		default:
+			lblMessage.Text = "Nothing to confirm. Click Cancel to go back.";
+			break;
 		}
 	}
 
@@ -140,45 +134,38 @@ public partial class Delete : System.Web.UI.Page
 	protected void cmdConfirm_Click (object sender, EventArgs e)
 	{
 		WebServiceResponse rsp = null;
+		switch (action) {
+		case "delete-lane":
+			Master.WebService.DeleteLane (Master.WebServiceLogin, lane_id);
+			break;
+		case "delete-host":
+			Master.WebService.DeleteHost (Master.WebServiceLogin, host_id);
+			break;
+		case "delete-all-work-for-host":
+			rsp = Master.WebService.DeleteAllWorkForHost (Master.WebServiceLogin, host_id);
+			break;
+		case "delete-all-work-for-lane":
+			rsp = Master.WebService.DeleteAllWorkForLane (Master.WebServiceLogin, lane_id);
+			break;
+		case "delete-all-revisions-for-lane":
+			rsp = Master.WebService.DeleteAllRevisionsForLane (Master.WebServiceLogin, lane_id);
+			break;
+		case "clear-all-work-for-host":
+			rsp = Master.WebService.ClearAllWorkForHost (Master.WebServiceLogin, host_id);
+			break;
+		case "clear-all-work-for-lane":
+			rsp = Master.WebService.ClearAllWorkForLane (Master.WebServiceLogin, lane_id);
+			break;
+		default:
+			lblMessage.Text = "Invalid action";
+			return;
+		}
 
-		try {
-			switch (action) {
-			case "delete-lane":
-				Master.WebService.DeleteLane (Master.WebServiceLogin, lane_id);
-				break;
-			case "delete-host":
-				Master.WebService.DeleteHost (Master.WebServiceLogin, host_id);
-				break;
-			case "delete-all-work-for-host":
-				rsp = Master.WebService.DeleteAllWorkForHost (Master.WebServiceLogin, host_id);
-				break;
-			case "delete-all-work-for-lane":
-				rsp = Master.WebService.DeleteAllWorkForLane (Master.WebServiceLogin, lane_id);
-				break;
-			case "delete-all-revisions-for-lane":
-				rsp = Master.WebService.DeleteAllRevisionsForLane (Master.WebServiceLogin, lane_id);
-				break;
-			case "clear-all-work-for-host":
-				rsp = Master.WebService.ClearAllWorkForHost (Master.WebServiceLogin, host_id);
-				break;
-			case "clear-all-work-for-lane":
-				rsp = Master.WebService.ClearAllWorkForLane (Master.WebServiceLogin, lane_id);
-				break;
-			default:
-				lblMessage.Text = "Invalid action";
-				return;
-			}
-
-			if (rsp != null && rsp.Exception != null) {
-				cmdConfirm.Enabled = false;
-				lblMessage.Text = Utils.FormatException (rsp.Exception.Message);
-			} else {
-				Redirect ();
-			}
-		} catch (Exception ex) {
+		if (rsp != null && rsp.Exception != null) {
 			cmdConfirm.Enabled = false;
-			cmdConfirm.Visible = false;
-			lblMessage.Text = Utils.FormatException (ex, true);
+			lblMessage.Text = Utils.FormatException (rsp.Exception.Message);
+		} else {
+			Redirect ();
 		}
 	}
 

--- a/MonkeyWrench.Web.UI/EditHost.aspx.cs
+++ b/MonkeyWrench.Web.UI/EditHost.aspx.cs
@@ -44,151 +44,147 @@ public partial class EditHost : System.Web.UI.Page
 		List<string> current_lanes = new List<string> ();
 		List<DBLane> all_lanes;
 
-		try {
-			string disable = Request ["disablelane"];
-			string enable = Request ["enablelane"];
-			string remove = Request ["removelane"];
-			string add = Request ["addlane"];
-			string action = Request ["action"];
-			int id;
-			bool redirect = false;
+		string disable = Request ["disablelane"];
+		string enable = Request ["enablelane"];
+		string remove = Request ["removelane"];
+		string add = Request ["addlane"];
+		string action = Request ["action"];
+		int id;
+		bool redirect = false;
 
-			txtID.Attributes ["readonly"] = "readonly";
+		txtID.Attributes ["readonly"] = "readonly";
 
-			response = Master.WebService.GetHostForEdit (Master.WebServiceLogin, Utils.TryParseInt32 (Request ["host_id"]), Request ["host"]);
+		response = Master.WebService.GetHostForEdit (Master.WebServiceLogin, Utils.TryParseInt32 (Request ["host_id"]), Request ["host"]);
 
-			if (response == null || response.Host == null) {
-				Response.Redirect ("EditHosts.aspx", false);
+		if (response == null || response.Host == null) {
+			Response.Redirect ("EditHosts.aspx", false);
+			return;
+		}
+
+		if (!IsPostBack) {
+			switch (action) {
+			case "editEnvironmentVariableValue":
+				if (int.TryParse (Request ["id"], out id)) {
+					foreach (DBEnvironmentVariable ev in response.Variables) {
+						if (ev.id == id) {
+							ev.value = Request ["value"];
+							Master.WebService.EditEnvironmentVariable (Master.WebServiceLogin, ev);
+							break;
+						}
+					}
+				}
+				redirect = true;
+				break;
+			}
+
+			if (!string.IsNullOrEmpty (disable) && int.TryParse (disable, out id)) {
+				Master.WebService.SwitchHostEnabledForLane (Master.WebServiceLogin, id, response.Host.id);
+				redirect = true;
+			}
+
+			if (!string.IsNullOrEmpty (enable) && int.TryParse (enable, out id)) {
+				Master.WebService.SwitchHostEnabledForLane (Master.WebServiceLogin, id, response.Host.id);
+				redirect = true;
+			}
+
+			if (!string.IsNullOrEmpty (remove) && int.TryParse (remove, out id)) {
+				Master.WebService.RemoveHostForLane (Master.WebServiceLogin, id, response.Host.id);
+				redirect = true;
+			}
+
+			if (!string.IsNullOrEmpty (add) && int.TryParse (add, out id)) {
+				Master.WebService.AddHostToLane (Master.WebServiceLogin, id, response.Host.id);
+				redirect = true;
+			}
+			if (redirect) {
+				RedirectToSelf ();
 				return;
 			}
 
-			if (!IsPostBack) {
-				switch (action) {
-				case "editEnvironmentVariableValue":
-					if (int.TryParse (Request ["id"], out id)) {
-						foreach (DBEnvironmentVariable ev in response.Variables) {
-							if (ev.id == id) {
-								ev.value = Request ["value"];
-								Master.WebService.EditEnvironmentVariable (Master.WebServiceLogin, ev);
-								break;
-							}
-						}
-					}
-					redirect = true;
-					break;
-				}
+			txtID.Text = response.Host.id.ToString ();
+			txtArchitecture.Text = response.Host.architecture;
+			txtDescription.Text = response.Host.description;
+			txtHost.Text = response.Host.host;
+			chkEnabled.Checked = response.Host.enabled;
+			cmbQueueManagement.SelectedIndex = response.Host.queuemanagement;
+			if (response.Person == null) {
+				string valid_chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMOPQRSUVWXYZ1234567890";
+				System.Text.StringBuilder builder = new System.Text.StringBuilder ();
+				Random random = new Random ();
+				for (int i = 0; i < 64; i++)
+					builder.Append ((char) valid_chars [random.Next (valid_chars.Length)]);
+				txtPassword.Text = builder.ToString ();
 
-				if (!string.IsNullOrEmpty (disable) && int.TryParse (disable, out id)) {
-					Master.WebService.SwitchHostEnabledForLane (Master.WebServiceLogin, id, response.Host.id);
-					redirect = true;
-				}
-
-				if (!string.IsNullOrEmpty (enable) && int.TryParse (enable, out id)) {
-					Master.WebService.SwitchHostEnabledForLane (Master.WebServiceLogin, id, response.Host.id);
-					redirect = true;
-				}
-
-				if (!string.IsNullOrEmpty (remove) && int.TryParse (remove, out id)) {
-					Master.WebService.RemoveHostForLane (Master.WebServiceLogin, id, response.Host.id);
-					redirect = true;
-				}
-
-				if (!string.IsNullOrEmpty (add) && int.TryParse (add, out id)) {
-					Master.WebService.AddHostToLane (Master.WebServiceLogin, id, response.Host.id);
-					redirect = true;
-				}
-				if (redirect) {
-					RedirectToSelf ();
-					return;
-				}
-
-				txtID.Text = response.Host.id.ToString ();
-				txtArchitecture.Text = response.Host.architecture;
-				txtDescription.Text = response.Host.description;
-				txtHost.Text = response.Host.host;
-				chkEnabled.Checked = response.Host.enabled;
-				cmbQueueManagement.SelectedIndex = response.Host.queuemanagement;
-				if (response.Person == null) {
-					string valid_chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMOPQRSUVWXYZ1234567890";
-					System.Text.StringBuilder builder = new System.Text.StringBuilder ();
-					Random random = new Random ();
-					for (int i = 0; i < 64; i++)
-						builder.Append ((char) valid_chars [random.Next (valid_chars.Length)]);
-					txtPassword.Text = builder.ToString ();
-
-					lblPasswordWarning.Text = "A password for the host has been generated, please hit Save to save it.";
-				} else {
-					txtPassword.Text = response.Person.password;
-				}
-
+				lblPasswordWarning.Text = "A password for the host has been generated, please hit Save to save it.";
+			} else {
+				txtPassword.Text = response.Person.password;
 			}
 
-			editorVariables.Host = response.Host;
-			editorVariables.Variables = response.Variables;
-			editorVariables.Master = Master;
+		}
 
-			foreach (DBHostLaneView view in response.HostLaneViews) {
-				string ed = view.enabled ? "enabled" : "disabled";
-				row = new TableRow ();
-				row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='EditLane.aspx?lane_id={0}'>{1}</a>", view.lane_id, view.lane), view.enabled ? "enabled" : "disabled"));
-				page = "EditHost.aspx?host_id=" + response.Host.id.ToString ();
-				html = "<a href='" + page + "&amp;removelane=" + view.lane_id.ToString () + "'>Remove</a> ";
-				row.Cells.Add (Utils.CreateTableCell (html, ed));
+		editorVariables.Host = response.Host;
+		editorVariables.Variables = response.Variables;
+		editorVariables.Master = Master;
 
-				html = "<a href='" + page + "&amp;" + (view.enabled ? "disable" : "enable") + "lane=" + view.lane_id.ToString () + "'>" + (view.enabled ? "Disable" : "Enable") + "</a>";
-				row.Cells.Add (Utils.CreateTableCell (html, ed));
-				tblLanes.Rows.Add (row);
-				current_lanes.Add (view.lane);
-			}
+		foreach (DBHostLaneView view in response.HostLaneViews) {
+			string ed = view.enabled ? "enabled" : "disabled";
+			row = new TableRow ();
+			row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='EditLane.aspx?lane_id={0}'>{1}</a>", view.lane_id, view.lane), view.enabled ? "enabled" : "disabled"));
+			page = "EditHost.aspx?host_id=" + response.Host.id.ToString ();
+			html = "<a href='" + page + "&amp;removelane=" + view.lane_id.ToString () + "'>Remove</a> ";
+			row.Cells.Add (Utils.CreateTableCell (html, ed));
 
-			all_lanes = response.Lanes;
-			if (all_lanes.Count != current_lanes.Count) {
-				row = new TableRow ();
-				html = "<select id='addhostlane'>";
-				foreach (DBLane lane in all_lanes) {
-					if (!current_lanes.Contains (lane.lane))
-						html += "<option value='" + lane.id + "'>" + lane.lane + "</option>";
-				}
-				html += "</select>";
-				row.Cells.Add (Utils.CreateTableCell (html));
-				row.Cells.Add (Utils.CreateTableCell ("<a href='javascript:addLane()'>Add</a>"));
-				row.Cells.Add (Utils.CreateTableCell ("-"));
-				tblLanes.Rows.Add (row);
-			}
+			html = "<a href='" + page + "&amp;" + (view.enabled ? "disable" : "enable") + "lane=" + view.lane_id.ToString () + "'>" + (view.enabled ? "Disable" : "Enable") + "</a>";
+			row.Cells.Add (Utils.CreateTableCell (html, ed));
+			tblLanes.Rows.Add (row);
+			current_lanes.Add (view.lane);
+		}
 
-			foreach (DBHost host in response.Hosts) {
-				if (response.MasterHosts.Find (d => host.id == d.id) != null)
-					continue; // don't add master hosts already added
-				if (response.SlaveHosts.Find (d => host.id == d.id) != null)
-					continue; // don't add any slave hosts, circular references is never a good thing
-				cmbMasterHosts.Items.Add (new ListItem (host.host, host.id.ToString ()));
+		all_lanes = response.Lanes;
+		if (all_lanes.Count != current_lanes.Count) {
+			row = new TableRow ();
+			html = "<select id='addhostlane'>";
+			foreach (DBLane lane in all_lanes) {
+				if (!current_lanes.Contains (lane.lane))
+					html += "<option value='" + lane.id + "'>" + lane.lane + "</option>";
 			}
-			foreach (DBHost host in response.MasterHosts) {
-				tblMasters.Rows.AddAt (1, Utils.CreateTableRow (
-					string.Format ("<a href='EditHost.aspx?host_id={0}'>{1}</a>", host.id, host.host),
-					Utils.CreateLinkButton ("removeMasterHostLinkButton_" + host.id.ToString (), "Remove", "RemoveMasterHost", host.id.ToString (), OnLinkButtonCommand)));
-			}
-			foreach (DBHost host in response.SlaveHosts) {
-				tblSlaves.Rows.AddAt (1, Utils.CreateTableRow (
-					string.Format ("<a href='EditHost.aspx?host_id={0}'>{1}</a>", host.id, host.host),
-					Utils.CreateLinkButton ("removeSaveHostLinkButton_" + host.id.ToString (), "Remove", "RemoveSlaveHost", host.id.ToString (), OnLinkButtonCommand)));
-			}
+			html += "</select>";
+			row.Cells.Add (Utils.CreateTableCell (html));
+			row.Cells.Add (Utils.CreateTableCell ("<a href='javascript:addLane()'>Add</a>"));
+			row.Cells.Add (Utils.CreateTableCell ("-"));
+			tblLanes.Rows.Add (row);
+		}
 
-			string txt = string.Format (@"
+		foreach (DBHost host in response.Hosts) {
+			if (response.MasterHosts.Find (d => host.id == d.id) != null)
+				continue; // don't add master hosts already added
+			if (response.SlaveHosts.Find (d => host.id == d.id) != null)
+				continue; // don't add any slave hosts, circular references is never a good thing
+			cmbMasterHosts.Items.Add (new ListItem (host.host, host.id.ToString ()));
+		}
+		foreach (DBHost host in response.MasterHosts) {
+			tblMasters.Rows.AddAt (1, Utils.CreateTableRow (
+				string.Format ("<a href='EditHost.aspx?host_id={0}'>{1}</a>", host.id, host.host),
+				Utils.CreateLinkButton ("removeMasterHostLinkButton_" + host.id.ToString (), "Remove", "RemoveMasterHost", host.id.ToString (), OnLinkButtonCommand)));
+		}
+		foreach (DBHost host in response.SlaveHosts) {
+			tblSlaves.Rows.AddAt (1, Utils.CreateTableRow (
+				string.Format ("<a href='EditHost.aspx?host_id={0}'>{1}</a>", host.id, host.host),
+				Utils.CreateLinkButton ("removeSaveHostLinkButton_" + host.id.ToString (), "Remove", "RemoveSlaveHost", host.id.ToString (), OnLinkButtonCommand)));
+		}
+
+		string txt = string.Format (@"
 <MonkeyWrench Version='2'>
-	<Configuration>
-		<WebServiceUrl>https://{0}/Wrench/WebServices/</WebServiceUrl>
-		<WebServicePassword>{1}</WebServicePassword>
-		<Host>{2}</Host>
-		<DataDirectory>[FULL PATH TO HOME DIRECTORY, NOT ~]/moonbuilder/data</DataDirectory>
-		<LockingAlgorithm>fileexistence</LockingAlgorithm>
-	</Configuration>
+<Configuration>
+	<WebServiceUrl>https://{0}/Wrench/WebServices/</WebServiceUrl>
+	<WebServicePassword>{1}</WebServicePassword>
+	<Host>{2}</Host>
+	<DataDirectory>[FULL PATH TO HOME DIRECTORY, NOT ~]/moonbuilder/data</DataDirectory>
+	<LockingAlgorithm>fileexistence</LockingAlgorithm>
+</Configuration>
 </MonkeyWrench>
 ", Request.Url.Host + (Request.Url.Port != 0 && Request.Url.Port != 80 ? ":" + Request.Url.Port.ToString () : ""), txtPassword.Text, txtHost.Text);
-			lblConfiguration.InnerHtml = "<pre>" + HttpUtility.HtmlEncode (txt) + "</pre>";
-		} catch (Exception ex) {
-			lblMessage.Text = Utils.FormatException (ex, true);
-		}
+		lblConfiguration.InnerHtml = "<pre>" + HttpUtility.HtmlEncode (txt) + "</pre>";
 	}
 
 	protected void OnLinkButtonCommand (object sender, CommandEventArgs e)
@@ -209,35 +205,23 @@ public partial class EditHost : System.Web.UI.Page
 
 	protected void cmdSave_Click (object sender, EventArgs e)
 	{
-		try {
-			DBHost host = response.Host;
-			host.host = txtHost.Text;
-			host.architecture = txtArchitecture.Text;
-			host.description = txtDescription.Text;
-			host.queuemanagement = cmbQueueManagement.SelectedIndex;
-			host.enabled = chkEnabled.Checked;
-			Master.WebService.EditHostWithPassword (Master.WebServiceLogin, host, txtPassword.Text);
-			RedirectToSelf ();
-		} catch (Exception ex) {
-			lblMessage.Text = Utils.FormatException (ex, true);
-		}
+		DBHost host = response.Host;
+		host.host = txtHost.Text;
+		host.architecture = txtArchitecture.Text;
+		host.description = txtDescription.Text;
+		host.queuemanagement = cmbQueueManagement.SelectedIndex;
+		host.enabled = chkEnabled.Checked;
+		Master.WebService.EditHostWithPassword (Master.WebServiceLogin, host, txtPassword.Text);
+		RedirectToSelf ();
 	}
 
 	protected void cmdDeleteAllWork_Click (object sender, EventArgs e)
 	{
-		try {
-			Response.Redirect ("Delete.aspx?action=delete-all-work-for-host&host_id=" + response.Host.id.ToString (), false);
-		} catch (Exception ex) {
-			lblMessage.Text = Utils.FormatException (ex, true);
-		}
+		Response.Redirect ("Delete.aspx?action=delete-all-work-for-host&host_id=" + response.Host.id.ToString (), false);
 	}
 
 	protected void cmdClearAllWork_Click (object sender, EventArgs e)
 	{
-		try {
-			Response.Redirect ("Delete.aspx?action=clear-all-work-for-host&host_id=" + response.Host.id.ToString (), false);
-		} catch (Exception ex) {
-			lblMessage.Text = Utils.FormatException (ex, true);
-		}
+		Response.Redirect ("Delete.aspx?action=clear-all-work-for-host&host_id=" + response.Host.id.ToString (), false);
 	}
 }

--- a/MonkeyWrench.Web.UI/EditHosts.aspx.cs
+++ b/MonkeyWrench.Web.UI/EditHosts.aspx.cs
@@ -79,13 +79,9 @@ public partial class EditHosts : System.Web.UI.Page
 				}
 			}
 		} else if (!string.IsNullOrEmpty (Request ["txtHost"])) {
-			try {
-				Master.WebService.AddHost (Master.WebServiceLogin, Request ["txtHost"]);
-				Response.Redirect ("EditHosts.aspx");
-				return;
-			} catch (Exception ex) {
-				lblMessage.Text = Utils.FormatException (ex);
-			}
+			Master.WebService.AddHost (Master.WebServiceLogin, Request ["txtHost"]);
+			Response.Redirect ("EditHosts.aspx");
+			return;
 		}
 
 		GetHostsResponse response = Master.WebService.GetHosts (Master.WebServiceLogin);

--- a/MonkeyWrench.Web.UI/EditLane.aspx.cs
+++ b/MonkeyWrench.Web.UI/EditLane.aspx.cs
@@ -42,439 +42,439 @@ public partial class EditLane : System.Web.UI.Page
 	protected override void OnInit (EventArgs e)
 	{
 		base.OnInit (e);
-		try {
-			TableRow row;
-			GetLaneForEditResponse response;
 
-			txtID.Attributes ["readonly"] = "readonly";
+		TableRow row;
+		GetLaneForEditResponse response;
 
-			string action = Request ["action"];
-			string command_id = Request ["command_id"];
+		txtID.Attributes ["readonly"] = "readonly";
 
-			int id;
-			int sequence;
-			int timeout;
-			
-			tblCommands.Visible = true;
-			tblFiles.Visible = true;
+		string action = Request ["action"];
+		string command_id = Request ["command_id"];
 
-			int.TryParse (Request ["lane_id"], out id);
-			response = Master.WebService.GetLaneForEdit (Master.WebServiceLogin, id, Request ["lane"]);
+		int id;
+		int sequence;
+		int timeout;
+		
+		tblCommands.Visible = true;
+		tblFiles.Visible = true;
 
-			lane = response.Lane;
+		int.TryParse (Request ["lane_id"], out id);
+		response = Master.WebService.GetLaneForEdit (Master.WebServiceLogin, id, Request ["lane"]);
 
-			if (lane == null) {
-				Response.Redirect ("EditLanes.aspx", false);
-				return;
-			}
+		lane = response.Lane;
 
-			lblH2.Text = "Lane: " + lane.lane;
+		if (lane == null) {
+			Response.Redirect ("EditLanes.aspx", false);
+			return;
+		}
+
+		lblH2.Text = "Lane: " + lane.lane;
 //			lblDeletionDirectiveErrors.Visible = false;
 
-			// find possible parent lanes
-			lstParentLane.Items.Clear ();
-			lstParentLane.Items.Add (new ListItem ("None", "0"));
-			foreach (DBLane l in response.Lanes) {
-				if (l.id == lane.id)
-					continue;
+		// find possible parent lanes
+		lstParentLane.Items.Clear ();
+		lstParentLane.Items.Add (new ListItem ("None", "0"));
+		foreach (DBLane l in response.Lanes) {
+			if (l.id == lane.id)
+				continue;
 
-				if (Utils.IsDescendentLaneOf (response.Lanes, lane, l, 0))
-					continue; // our descendents can't be our parents too.
+			if (Utils.IsDescendentLaneOf (response.Lanes, lane, l, 0))
+				continue; // our descendents can't be our parents too.
 
-				lstParentLane.Items.Add (new ListItem (l.lane, l.id.ToString ()));
-
-				if (!IsPostBack) {
-					if (lane.parent_lane_id.HasValue && lane.parent_lane_id.Value == l.id)
-						lstParentLane.SelectedIndex = lstParentLane.Items.Count - 1;
-				}
-			}
+			lstParentLane.Items.Add (new ListItem (l.lane, l.id.ToString ()));
 
 			if (!IsPostBack) {
-				for (int i = 0; i < cmbSourceControl.Items.Count; i++) {
-					cmbSourceControl.Items [i].Selected = lane.source_control == cmbSourceControl.Items [i].Text;
+				if (lane.parent_lane_id.HasValue && lane.parent_lane_id.Value == l.id)
+					lstParentLane.SelectedIndex = lstParentLane.Items.Count - 1;
+			}
+		}
+
+		if (!IsPostBack) {
+			for (int i = 0; i < cmbSourceControl.Items.Count; i++) {
+				cmbSourceControl.Items [i].Selected = lane.source_control == cmbSourceControl.Items [i].Text;
+			}
+			txtRepository.Text = lane.repository;
+			txtCommitFilter.Text = lane.commit_filter;
+			txtMinRevision.Text = lane.min_revision;
+			txtMaxRevision.Text = lane.max_revision;
+			if (response.Tags != null)
+				txtTags.Text = string.Join (",", response.Tags.ConvertAll<string> ((DBLaneTag tag) => tag.tag).ToArray ());
+			txtLane.Text = lane.lane;
+			txtID.Text = lane.id.ToString ();
+			// find (direct) child lanes
+			foreach (DBLane l in response.Lanes) {
+				if (l.parent_lane_id.HasValue && l.parent_lane_id.Value == lane.id) {
+					if (!string.IsNullOrEmpty (lblChildLanes.Text))
+						lblChildLanes.Text += ", ";
+					lblChildLanes.Text += string.Format ("<a href='EditLane.aspx?lane_id={0}'>{1}</a>", l.id, l.lane);
 				}
-				txtRepository.Text = lane.repository;
-				txtCommitFilter.Text = lane.commit_filter;
-				txtMinRevision.Text = lane.min_revision;
-				txtMaxRevision.Text = lane.max_revision;
-				if (response.Tags != null)
-					txtTags.Text = string.Join (",", response.Tags.ConvertAll<string> ((DBLaneTag tag) => tag.tag).ToArray ());
-				txtLane.Text = lane.lane;
-				txtID.Text = lane.id.ToString ();
-				// find (direct) child lanes
-				foreach (DBLane l in response.Lanes) {
-					if (l.parent_lane_id.HasValue && l.parent_lane_id.Value == lane.id) {
-						if (!string.IsNullOrEmpty (lblChildLanes.Text))
-							lblChildLanes.Text += ", ";
-						lblChildLanes.Text += string.Format ("<a href='EditLane.aspx?lane_id={0}'>{1}</a>", l.id, l.lane);
+			}
+			chkTraverseMerges.Checked = lane.traverse_merge;
+			chkEnabled.Checked = lane.enabled;
+		}
+
+		if (!string.IsNullOrEmpty (action)) {
+			switch (action) {
+			case "createFile":
+				Master.WebService.CreateLanefile (Master.WebServiceLogin, lane.id, Request ["filename"]);
+				break;
+			case "addFile":
+				if (int.TryParse (Request ["lanefile_id"], out id))
+					Master.WebService.AttachFileToLane (Master.WebServiceLogin, lane.id, id);
+				break;
+			case "deleteFile":
+				if (int.TryParse (Request ["file_id"], out id))
+					Master.WebService.DeattachFileFromLane (Master.WebServiceLogin, lane.id, id);
+				break;
+			case "editCommandFilename":
+				if (int.TryParse (command_id, out id))
+					Master.WebService.EditCommandFilename (Master.WebServiceLogin, id, Request ["filename"]);
+				break;
+			case "editCommandSequence":
+				if (int.TryParse (command_id, out id)) {
+					if (int.TryParse (Request ["sequence"], out sequence))
+						Master.WebService.EditCommandSequence (Master.WebServiceLogin, id, sequence);
+				}
+				break;
+			case "editCommandArguments":
+				if (int.TryParse (command_id, out id))
+					Master.WebService.EditCommandArguments (Master.WebServiceLogin, id, Request ["arguments"]);
+				break;
+			case "editCommandTimeout":
+				if (int.TryParse (command_id, out id)) {
+					if (int.TryParse (Request ["timeout"], out timeout))
+						Master.WebService.EditCommandTimeout (Master.WebServiceLogin, id, timeout);
+				}
+				break;
+			case "editCommandWorkingDirectory":
+				if (int.TryParse (command_id, out id))
+					Master.WebService.EditCommandWorkingDirectory (Master.WebServiceLogin, id, Request ["working_directory"]);
+				break;
+			case "editCommandUploadFiles":
+				if (int.TryParse (command_id, out id))
+					Master.WebService.EditCommandUploadFiles (Master.WebServiceLogin, id, Request ["upload_files"]);
+				break;
+			case "deletecommand":
+				if (int.TryParse (command_id, out id))
+					Master.WebService.DeleteCommand (Master.WebServiceLogin, id);
+				break;
+			case "switchNonFatal":
+				if (int.TryParse (command_id, out id))
+					Master.WebService.SwitchCommandNonFatal (Master.WebServiceLogin, id);
+				break;
+			case "switchAlwaysExecute":
+				if (int.TryParse (command_id, out id))
+					Master.WebService.SwitchCommandAlwaysExecute (Master.WebServiceLogin, id);
+				break;
+			case "switchInternal":
+				if (int.TryParse (command_id, out id))
+					Master.WebService.SwitchCommandInternal (Master.WebServiceLogin, id);
+				break;
+			case "addCommand":
+				if (!int.TryParse (Request ["sequence"], out sequence))
+					sequence = -1;
+				Master.WebService.AddCommand (Master.WebServiceLogin, lane.id, Request ["command"], false, false, 60, sequence);
+				break;
+			case "switchHostEnabled":
+				if (int.TryParse (Request ["host_id"], out id))
+					Master.WebService.SwitchHostEnabledForLane (Master.WebServiceLogin, lane.id, id);
+				break;
+			case "switchHostHidden":
+				if (int.TryParse (Request ["host_id"], out id))
+					Master.WebService.SwitchHostHiddenForLane (Master.WebServiceLogin, lane.id, id);
+				break;
+			case "removeHost":
+				if (int.TryParse (Request ["host_id"], out id))
+					Master.WebService.RemoveHostForLane (Master.WebServiceLogin, lane.id, id);
+				break;
+			case "addHost":
+				if (int.TryParse (Request ["host_id"], out id))
+					Master.WebService.AddHostToLane (Master.WebServiceLogin, lane.id, id);
+				break;
+			case "addDependency":
+				if (int.TryParse (Request ["dependent_lane_id"], out id)) {
+					int condition;
+					int host_id;
+					if (int.TryParse (Request ["condition"], out condition)) {
+						if (int.TryParse (Request ["dependent_host_id"], out host_id)) {
+							Master.WebService.AddDependencyToLane (Master.WebServiceLogin, lane.id, id, host_id > 0 ? (Nullable<int>) host_id : (Nullable<int>) null, (DBLaneDependencyCondition) condition);
+						}
 					}
 				}
-				chkTraverseMerges.Checked = lane.traverse_merge;
-				chkEnabled.Checked = lane.enabled;
+				break;
+			case "editDependencyFilename":
+				if (int.TryParse (Request ["lanedependency_id"], out id))
+					Master.WebService.EditLaneDependencyFilename (Master.WebServiceLogin, id, Request ["filename"]);
+				break;
+			case "deleteDependency":
+				if (int.TryParse (Request ["dependency_id"], out id))
+					Master.WebService.DeleteLaneDependency (Master.WebServiceLogin, id);
+				break;
+			case "editDependencyDownloads":
+				if (int.TryParse (Request ["lanedependency_id"], out id))
+					Master.WebService.EditLaneDependencyDownloads (Master.WebServiceLogin, id, Request ["downloads"]);
+				break;
+			case "editEnvironmentVariableValue": {
+				int host_id, lane_id;
+				if (int.TryParse (Request ["host_id"], out host_id))
+					if (int.TryParse (Request ["lane_id"], out lane_id)) {
+						if (int.TryParse (Request ["id"], out id)) {
+							DBEnvironmentVariable ev = new DBEnvironmentVariable ();
+							ev.id = id;
+							ev.host_id = host_id == 0 ? (int?)null : host_id;
+							ev.lane_id = lane_id == 0 ? (int?)null : lane_id;
+							ev.name = Request ["name"];
+							ev.value = Request ["value"];
+							Master.WebService.EditEnvironmentVariable (Master.WebServiceLogin, ev);
+						}
+					}
+				}
+				break;
+			case "moveCommandToParentLane": {
+					if (int.TryParse (command_id, out id)) {
+						if (response.Lane.parent_lane_id != null) {
+							DBCommand cmd = response.Commands.Find ((v) => v.id == id);
+							if (cmd != null) {
+								cmd.lane_id = response.Lane.parent_lane_id.Value;
+								Master.WebService.EditCommand (Master.WebServiceLogin, cmd);
+							}
+						}
+					}
+				}
+				break;
+			default:
+				break;
 			}
 
-			if (!string.IsNullOrEmpty (action)) {
-				switch (action) {
-				case "createFile":
-					Master.WebService.CreateLanefile (Master.WebServiceLogin, lane.id, Request ["filename"]);
-					break;
-				case "addFile":
-					if (int.TryParse (Request ["lanefile_id"], out id))
-						Master.WebService.AttachFileToLane (Master.WebServiceLogin, lane.id, id);
-					break;
-				case "deleteFile":
-					if (int.TryParse (Request ["file_id"], out id))
-						Master.WebService.DeattachFileFromLane (Master.WebServiceLogin, lane.id, id);
-					break;
-				case "editCommandFilename":
-					if (int.TryParse (command_id, out id))
-						Master.WebService.EditCommandFilename (Master.WebServiceLogin, id, Request ["filename"]);
-					break;
-				case "editCommandSequence":
-					if (int.TryParse (command_id, out id)) {
-						if (int.TryParse (Request ["sequence"], out sequence))
-							Master.WebService.EditCommandSequence (Master.WebServiceLogin, id, sequence);
-					}
-					break;
-				case "editCommandArguments":
-					if (int.TryParse (command_id, out id))
-						Master.WebService.EditCommandArguments (Master.WebServiceLogin, id, Request ["arguments"]);
-					break;
-				case "editCommandTimeout":
-					if (int.TryParse (command_id, out id)) {
-						if (int.TryParse (Request ["timeout"], out timeout))
-							Master.WebService.EditCommandTimeout (Master.WebServiceLogin, id, timeout);
-					}
-					break;
-				case "editCommandWorkingDirectory":
-					if (int.TryParse (command_id, out id))
-						Master.WebService.EditCommandWorkingDirectory (Master.WebServiceLogin, id, Request ["working_directory"]);
-					break;
-				case "editCommandUploadFiles":
-					if (int.TryParse (command_id, out id))
-						Master.WebService.EditCommandUploadFiles (Master.WebServiceLogin, id, Request ["upload_files"]);
-					break;
-				case "deletecommand":
-					if (int.TryParse (command_id, out id))
-						Master.WebService.DeleteCommand (Master.WebServiceLogin, id);
-					break;
-				case "switchNonFatal":
-					if (int.TryParse (command_id, out id))
-						Master.WebService.SwitchCommandNonFatal (Master.WebServiceLogin, id);
-					break;
-				case "switchAlwaysExecute":
-					if (int.TryParse (command_id, out id))
-						Master.WebService.SwitchCommandAlwaysExecute (Master.WebServiceLogin, id);
-					break;
-				case "switchInternal":
-					if (int.TryParse (command_id, out id))
-						Master.WebService.SwitchCommandInternal (Master.WebServiceLogin, id);
-					break;
-				case "addCommand":
-					if (!int.TryParse (Request ["sequence"], out sequence))
-						sequence = -1;
-					Master.WebService.AddCommand (Master.WebServiceLogin, lane.id, Request ["command"], false, false, 60, sequence);
-					break;
-				case "switchHostEnabled":
-					if (int.TryParse (Request ["host_id"], out id))
-						Master.WebService.SwitchHostEnabledForLane (Master.WebServiceLogin, lane.id, id);
-					break;
-				case "switchHostHidden":
-					if (int.TryParse (Request ["host_id"], out id))
-						Master.WebService.SwitchHostHiddenForLane (Master.WebServiceLogin, lane.id, id);
-					break;
-				case "removeHost":
-					if (int.TryParse (Request ["host_id"], out id))
-						Master.WebService.RemoveHostForLane (Master.WebServiceLogin, lane.id, id);
-					break;
-				case "addHost":
-					if (int.TryParse (Request ["host_id"], out id))
-						Master.WebService.AddHostToLane (Master.WebServiceLogin, lane.id, id);
-					break;
-				case "addDependency":
-					if (int.TryParse (Request ["dependent_lane_id"], out id)) {
-						int condition;
-						int host_id;
-						if (int.TryParse (Request ["condition"], out condition)) {
-							if (int.TryParse (Request ["dependent_host_id"], out host_id)) {
-								Master.WebService.AddDependencyToLane (Master.WebServiceLogin, lane.id, id, host_id > 0 ? (Nullable<int>) host_id : (Nullable<int>) null, (DBLaneDependencyCondition) condition);
-							}
-						}
-					}
-					break;
-				case "editDependencyFilename":
-					if (int.TryParse (Request ["lanedependency_id"], out id))
-						Master.WebService.EditLaneDependencyFilename (Master.WebServiceLogin, id, Request ["filename"]);
-					break;
-				case "deleteDependency":
-					if (int.TryParse (Request ["dependency_id"], out id))
-						Master.WebService.DeleteLaneDependency (Master.WebServiceLogin, id);
-					break;
-				case "editDependencyDownloads":
-					if (int.TryParse (Request ["lanedependency_id"], out id))
-						Master.WebService.EditLaneDependencyDownloads (Master.WebServiceLogin, id, Request ["downloads"]);
-					break;
-				case "editEnvironmentVariableValue": {
-					int host_id, lane_id;
-					if (int.TryParse (Request ["host_id"], out host_id))
-						if (int.TryParse (Request ["lane_id"], out lane_id)) {
-							if (int.TryParse (Request ["id"], out id)) {
-								DBEnvironmentVariable ev = new DBEnvironmentVariable ();
-								ev.id = id;
-								ev.host_id = host_id == 0 ? (int?)null : host_id;
-								ev.lane_id = lane_id == 0 ? (int?)null : lane_id;
-								ev.name = Request ["name"];
-								ev.value = Request ["value"];
-								Master.WebService.EditEnvironmentVariable (Master.WebServiceLogin, ev);
-							}
-						}
-					}
-					break;
-				case "moveCommandToParentLane": {
-						if (int.TryParse (command_id, out id)) {
-							if (response.Lane.parent_lane_id != null) {
-								DBCommand cmd = response.Commands.Find ((v) => v.id == id);
-								if (cmd != null) {
-									cmd.lane_id = response.Lane.parent_lane_id.Value;
-									Master.WebService.EditCommand (Master.WebServiceLogin, cmd);
-								}
-							}
-						}
-					}
-					break;
-				default:
-					break;
-				}
+			RedirectToSelf ();
+			return;
+		}
 
-				RedirectToSelf ();
-				return;
-			}
+		// Files
+		var shown_files = new HashSet<int> ();
+		foreach (DBLanefile file in response.Files) {
+			if (shown_files.Contains (file.id))
+				continue;
+			shown_files.Add (file.id);
 
-			// Files
-			var shown_files = new HashSet<int> ();
-			foreach (DBLanefile file in response.Files) {
-				if (shown_files.Contains (file.id))
-					continue;
-				shown_files.Add (file.id);
+			string text = file.name;
+			if (!string.IsNullOrEmpty (file.mime))
+				text += " (" + file.mime + ")";
 
-				string text = file.name;
-				if (!string.IsNullOrEmpty (file.mime))
-					text += " (" + file.mime + ")";
+			bool is_inherited = !response.LaneFiles.Exists ((v) => v.lane_id == lane.id && v.lanefile_id == file.id);
 
-				bool is_inherited = !response.LaneFiles.Exists ((v) => v.lane_id == lane.id && v.lanefile_id == file.id);
-
-				var file_used_list = GetLanesWhereFileIsUsed (file, response).Where ((l) => l.id != lane.id).Select ((l, s) => string.Format ("<a href='EditLane.aspx?lane_id={0}'>{1}</a>", l.id, l.lane)).ToArray ();
-				var file_list = string.Format (
+			var file_used_list = GetLanesWhereFileIsUsed (file, response).Where ((l) => l.id != lane.id).Select ((l, s) => string.Format ("<a href='EditLane.aspx?lane_id={0}'>{1}</a>", l.id, l.lane)).ToArray ();
+			var file_list = string.Format (
 @"
 <div id=""hideFileList{2}"" style=""display: none;""  onclick=""document.getElementById('fileList{2}').style.display = 'none';  document.getElementById('hideFileList{2}').style.display = 'none';  document.getElementById('showFileList{2}').style.display = 'block';""  >[Hide]</div>
 <div id=""showFileList{2}"" style=""display: block;"" onclick=""document.getElementById('fileList{2}').style.display = 'block'; document.getElementById('hideFileList{2}').style.display = 'block'; document.getElementById('showFileList{2}').style.display = 'none' ; "" >Used by {0} other lanes [Show]</div>
 <div id=""fileList{2}"" style=""display: none;"">{1}</div>
 ", file_used_list.Length, string.Join (", ", file_used_list), file.id);
 
-				tblFiles.Rows.Add (Utils.CreateTableRow (
-					string.Format ("<a href='EditLaneFile.aspx?lane_id={1}&amp;file_id={0}'>{2}</a>", file.id, lane.id, file.name),
-					file.mime,
-					(is_inherited ? string.Empty : string.Format ("<a href='EditLane.aspx?lane_id={1}&amp;action=deleteFile&amp;file_id={0}'>Delete</a> ", file.id, lane.id)) + string.Format ("<a href='ViewLaneFileHistory.aspx?id={0}'>View history</a>", file.id),
-					file_list.ToString ()));
-
-				if (is_inherited)
-					tblFiles.Rows [tblFiles.Rows.Count - 1].BackColor = System.Drawing.Color.LightGray;
-			}
 			tblFiles.Rows.Add (Utils.CreateTableRow (
-				"<input type='text' value='filename' id='txtCreateFileName'></input>",
-				"text/plain",
-				string.Format ("<a href='javascript:createFile ({0})'>Add</a>", lane.id),
-				"-"
-				));
-			StringBuilder existing_files = new StringBuilder ();
-			existing_files.AppendLine ("<select id='cmbExistingFiles'>");
-			response.ExistingFiles.Sort ((a, b) => string.Compare (a.name, b.name));
-			shown_files.Clear ();
+				string.Format ("<a href='EditLaneFile.aspx?lane_id={1}&amp;file_id={0}'>{2}</a>", file.id, lane.id, file.name),
+				file.mime,
+				(is_inherited ? string.Empty : string.Format ("<a href='EditLane.aspx?lane_id={1}&amp;action=deleteFile&amp;file_id={0}'>Delete</a> ", file.id, lane.id)) + string.Format ("<a href='ViewLaneFileHistory.aspx?id={0}'>View history</a>", file.id),
+				file_list.ToString ()));
 
-			// build dictionary of lanes
-			var laneDictionary = new Dictionary<int, DBLane> ();
-			foreach (var l in response.Lanes)
-				laneDictionary.Add (l.id, l);
+			if (is_inherited)
+				tblFiles.Rows [tblFiles.Rows.Count - 1].BackColor = System.Drawing.Color.LightGray;
+		}
+		tblFiles.Rows.Add (Utils.CreateTableRow (
+			"<input type='text' value='filename' id='txtCreateFileName'></input>",
+			"text/plain",
+			string.Format ("<a href='javascript:createFile ({0})'>Add</a>", lane.id),
+			"-"
+			));
+		StringBuilder existing_files = new StringBuilder ();
+		existing_files.AppendLine ("<select id='cmbExistingFiles'>");
+		response.ExistingFiles.Sort ((a, b) => string.Compare (a.name, b.name));
+		shown_files.Clear ();
 
-			// build table of lanes where each file is used
-			var lanesUsedByFile = new Dictionary<int, HashSet<string>> ();
-			foreach (var lf in response.LaneFiles) {
-				HashSet<string> f;
-				if (!lanesUsedByFile.TryGetValue (lf.lanefile_id, out f)) {
-					f = new HashSet<string> ();
-					lanesUsedByFile [lf.lanefile_id] = f;
-				}
-				f.Add (laneDictionary [lf.lane_id].lane);
+		// build dictionary of lanes
+		var laneDictionary = new Dictionary<int, DBLane> ();
+		foreach (var l in response.Lanes)
+			laneDictionary.Add (l.id, l);
+
+		// build table of lanes where each file is used
+		var lanesUsedByFile = new Dictionary<int, HashSet<string>> ();
+		foreach (var lf in response.LaneFiles) {
+			HashSet<string> f;
+			if (!lanesUsedByFile.TryGetValue (lf.lanefile_id, out f)) {
+				f = new HashSet<string> ();
+				lanesUsedByFile [lf.lanefile_id] = f;
 			}
-			// list all the files, with a tooltip saying where each file is used
-			foreach (DBLanefile file in response.ExistingFiles) {
-				if (shown_files.Contains (file.id))
-					continue;
-				shown_files.Add (file.id);
+			f.Add (laneDictionary [lf.lane_id].lane);
+		}
+		// list all the files, with a tooltip saying where each file is used
+		foreach (DBLanefile file in response.ExistingFiles) {
+			if (shown_files.Contains (file.id))
+				continue;
+			shown_files.Add (file.id);
 
-				existing_files.AppendFormat ("<option value='{0}'", file.id);
-				HashSet<string> lanes_for_file;
-				if (lanesUsedByFile.TryGetValue (file.id, out lanes_for_file)) {
-					existing_files.Append (" title='Used in: ");
-					var any = false;
-					foreach (var l in lanes_for_file) {
-						if (any) {
-							existing_files.Append (", ");
-						} else {
-							any = true;
-						}
-						existing_files.Append (l);
+			existing_files.AppendFormat ("<option value='{0}'", file.id);
+			HashSet<string> lanes_for_file;
+			if (lanesUsedByFile.TryGetValue (file.id, out lanes_for_file)) {
+				existing_files.Append (" title='Used in: ");
+				var any = false;
+				foreach (var l in lanes_for_file) {
+					if (any) {
+						existing_files.Append (", ");
+					} else {
+						any = true;
 					}
-					existing_files.Append ("'");
+					existing_files.Append (l);
 				}
-				existing_files.Append (">");
-				existing_files.Append (file.name);
-				existing_files.Append ("</option>\n");
+				existing_files.Append ("'");
+			}
+			existing_files.Append (">");
+			existing_files.Append (file.name);
+			existing_files.Append ("</option>\n");
 //				existing_files.AppendFormat ("<option value='{1}' title='Used in: {2}'>{0}</option>\n", file.name, file.id, "somewhere else");
-			}
-			existing_files.AppendLine ("</select>");
-			tblFiles.Rows.Add (Utils.CreateTableRow (
-				existing_files.ToString (),
-				"N/A",
-				string.Format ("<a href='javascript:addFile ({0})'>Add</a>", lane.id),
-				"-"
-				));
-			tblFiles.Visible = true;
+		}
+		existing_files.AppendLine ("</select>");
+		tblFiles.Rows.Add (Utils.CreateTableRow (
+			existing_files.ToString (),
+			"N/A",
+			string.Format ("<a href='javascript:addFile ({0})'>Add</a>", lane.id),
+			"-"
+			));
+		tblFiles.Visible = true;
 
-			// commands
-			foreach (DBCommand command in response.Commands) {
-				string filename = command.command;
-				DBLanefile file = Utils.FindFile (response.Files, f => f.name == filename);
-				if (file != null)
-					filename = string.Format ("<a href='EditLaneFile.aspx?lane_id={1}&amp;file_id={0}'>{2}</a>", file.id, lane.id, file.name);
+		// commands
+		foreach (DBCommand command in response.Commands) {
+			string filename = command.command;
+			DBLanefile file = Utils.FindFile (response.Files, f => f.name == filename);
+			if (file != null)
+				filename = string.Format ("<a href='EditLaneFile.aspx?lane_id={1}&amp;file_id={0}'>{2}</a>", file.id, lane.id, file.name);
 
-				string working_directory = "<em>modify</em>";
-				if (!string.IsNullOrEmpty(command.working_directory))
-				    working_directory = command.working_directory;
-				string upload_files = "<em>modify</em>";
-				if (!string.IsNullOrEmpty(command.upload_files))
-				    upload_files = command.upload_files;
+			string working_directory = "<em>modify</em>";
+			if (!string.IsNullOrEmpty(command.working_directory))
+			    working_directory = command.working_directory;
+			string upload_files = "<em>modify</em>";
+			if (!string.IsNullOrEmpty(command.upload_files))
+			    upload_files = command.upload_files;
 
-				bool is_inherited = command.lane_id != lane.id;
+			bool is_inherited = command.lane_id != lane.id;
 
-				tblCommands.Rows.Add (Utils.CreateTableRow (
-					string.Format ("<a href='javascript:editCommandSequence ({2}, {0}, true, \"{1}\")'>{1}</a>", command.id, command.sequence, lane.id),
-					filename,
-					string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;command_id={3}&amp;action=switchAlwaysExecute'>{2}</a>", lane.id, (!command.alwaysexecute).ToString (), command.alwaysexecute ? "yes" : "no", command.id),
-					string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;command_id={3}&amp;action=switchNonFatal'>{2}</a>", lane.id, (!command.nonfatal).ToString (), command.nonfatal ? "yes" : "no", command.id),
-					string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;command_id={1}&amp;action=switchInternal'>{2}</a>", lane.id, command.id, (command.@internal ? "yes" : "no")),
-					string.Format ("<a href='javascript:editCommandFilename ({2}, {0}, true, \"{1}\")'>{1}</a>", command.id, command.filename, lane.id),
-					string.Format ("<a href='javascript:editCommandArguments ({2}, {0}, true, \"{1}\")'>{3}</a>", command.id, command.arguments.Replace ("\"", "\\\""), lane.id, command.arguments),
-					string.Format ("<a href='javascript:editCommandTimeout ({2}, {0}, true, \"{1}\")'>{1} minutes</a>", command.id, command.timeout, lane.id),
-				    string.Format ("<a href='javascript:editCommandWorkingDirectory ({2}, {0}, true, \"{1}\")'>{3}</a>", command.id, command.working_directory, lane.id, working_directory),
-					string.Format ("<a href='javascript:editCommandUploadFiles ({2}, {0}, true, \"{1}\")'>{3}</a>", command.id, command.upload_files, lane.id, upload_files),
-					is_inherited ? "-" : string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;action=deletecommand&amp;command_id={1}'>Delete</a>", lane.id, command.id),
-					is_inherited ? string.Format ("Inherited from <a href='EditLane.aspx?lane_id={1}'>{0}</a>", response.Lanes.Find ((v) => v.id == command.lane_id).lane, command.lane_id) : (lane.parent_lane_id == null ? "-" : string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;command_id={1}&amp;action=moveCommandToParentLane'>Move</a> to parent lane", lane.id, command.id, lane.parent_lane_id.Value))));
-
-				if (is_inherited)
-					tblCommands.Rows [tblCommands.Rows.Count - 1].BackColor = System.Drawing.Color.LightGray;
-			}
 			tblCommands.Rows.Add (Utils.CreateTableRow (
-				(response.Commands.Count * 10).ToString (),
-				string.Format ("<input type='text' value='command' id='txtCreateCommand_name'></input>"),
-				"no",
-				"no",
-				"no",
-				"bash",
-				"-ex {0}",
-				"60 minutes",
-				"-",
-				"-",
-				string.Format ("<a href='javascript:addCommand ({0}, {1})'>Add</a>", lane.id, response.Commands.Count > 0 ? (response.Commands [response.Commands.Count - 1].sequence + 10) : 0),
-				"-"));
+				string.Format ("<a href='javascript:editCommandSequence ({2}, {0}, true, \"{1}\")'>{1}</a>", command.id, command.sequence, lane.id),
+				filename,
+				string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;command_id={3}&amp;action=switchAlwaysExecute'>{2}</a>", lane.id, (!command.alwaysexecute).ToString (), command.alwaysexecute ? "yes" : "no", command.id),
+				string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;command_id={3}&amp;action=switchNonFatal'>{2}</a>", lane.id, (!command.nonfatal).ToString (), command.nonfatal ? "yes" : "no", command.id),
+				string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;command_id={1}&amp;action=switchInternal'>{2}</a>", lane.id, command.id, (command.@internal ? "yes" : "no")),
+				string.Format ("<a href='javascript:editCommandFilename ({2}, {0}, true, \"{1}\")'>{1}</a>", command.id, command.filename, lane.id),
+				string.Format ("<a href='javascript:editCommandArguments ({2}, {0}, true, \"{1}\")'>{3}</a>", command.id, command.arguments.Replace ("\"", "\\\""), lane.id, command.arguments),
+				string.Format ("<a href='javascript:editCommandTimeout ({2}, {0}, true, \"{1}\")'>{1} minutes</a>", command.id, command.timeout, lane.id),
+			    string.Format ("<a href='javascript:editCommandWorkingDirectory ({2}, {0}, true, \"{1}\")'>{3}</a>", command.id, command.working_directory, lane.id, working_directory),
+				string.Format ("<a href='javascript:editCommandUploadFiles ({2}, {0}, true, \"{1}\")'>{3}</a>", command.id, command.upload_files, lane.id, upload_files),
+				is_inherited ? "-" : string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;action=deletecommand&amp;command_id={1}'>Delete</a>", lane.id, command.id),
+				is_inherited ? string.Format ("Inherited from <a href='EditLane.aspx?lane_id={1}'>{0}</a>", response.Lanes.Find ((v) => v.id == command.lane_id).lane, command.lane_id) : (lane.parent_lane_id == null ? "-" : string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;command_id={1}&amp;action=moveCommandToParentLane'>Move</a> to parent lane", lane.id, command.id, lane.parent_lane_id.Value))));
 
-			// Show all the hosts
-			List<string> current_hosts = new List<string> ();
-			string html;
+			if (is_inherited)
+				tblCommands.Rows [tblCommands.Rows.Count - 1].BackColor = System.Drawing.Color.LightGray;
+		}
+		tblCommands.Rows.Add (Utils.CreateTableRow (
+			(response.Commands.Count * 10).ToString (),
+			string.Format ("<input type='text' value='command' id='txtCreateCommand_name'></input>"),
+			"no",
+			"no",
+			"no",
+			"bash",
+			"-ex {0}",
+			"60 minutes",
+			"-",
+			"-",
+			string.Format ("<a href='javascript:addCommand ({0}, {1})'>Add</a>", lane.id, response.Commands.Count > 0 ? (response.Commands [response.Commands.Count - 1].sequence + 10) : 0),
+			"-"));
 
-			foreach (DBHostLaneView view in response.HostLaneViews) {
-				string ed = view.enabled ? "enabled" : "disabled";
-				string hid = view.hidden ? "hidden" : "visible";
-				string @class = ed + " " + hid;
-				row = new TableRow ();
+		// Show all the hosts
+		List<string> current_hosts = new List<string> ();
+		string html;
 
-				row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='EditHost.aspx?host_id={0}'>{1}</a>", view.host_id, view.host), @class));
-				html = string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;host_id={1}&amp;action=removeHost'>Remove</a> ", lane.id, view.host_id);
-				html = html + string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;host_id={1}&amp;action=switchHostEnabled'>{2}</a> ", lane.id, view.host_id, (view.enabled ? "Disable" : "Enable"));
-				html = html + string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;host_id={1}&amp;action=switchHostHidden'>{2}</a>", lane.id, view.host_id, (view.hidden ? "Show" : "Hide"));
-				row.Cells.Add (Utils.CreateTableCell (html, @class));
-				tblHosts.Rows.Add (row);
-				current_hosts.Add (view.host);
-			}
-
-			if (response.Hosts.Count != current_hosts.Count) {
-				row = new TableRow ();
-				html = "<select id='lstHosts'>";
-				foreach (DBHost host in response.Hosts) {
-					if (!current_hosts.Contains (host.host))
-						html += "<option value='" + host.id + "'>" + host.host + "</option>";
-				}
-				html += "</select>";
-				row.Cells.Add (Utils.CreateTableCell (html));
-				row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript:addHost({0})'>Add</a>", lane.id)));
-				tblHosts.Rows.Add (row);
-			}
-
-			// dependencies
-			foreach (DBLaneDependency dependency in response.Dependencies) {
-				row = new TableRow ();
-				for (int i = 0; i < response.Lanes.Count; i++) {
-					if (response.Lanes [i].id == dependency.dependent_lane_id) {
-						row.Cells.Add (Utils.CreateTableCell (response.Lanes [i].lane));
-						break;
-					}
-				}
-				row.Cells.Add (Utils.CreateTableCell (dependency.Condition.ToString ()));
-				row.Cells.Add (Utils.CreateTableCell (dependency.dependent_host_id.HasValue ? Utils.FindHost (response.Hosts, dependency.dependent_host_id.Value).host : "Any"));
-				switch (dependency.Condition) {
-				case DBLaneDependencyCondition.DependentLaneSuccessWithFile:
-					row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript: editDependencyFilename ({0}, {1}, \"{2}\")'>{2}</a>", lane.id, dependency.id, string.IsNullOrEmpty (dependency.filename) ? "(edit)" : dependency.filename)));
-					break;
-				case DBLaneDependencyCondition.DependentLaneSuccess:
-				case DBLaneDependencyCondition.DependentLaneIssuesOrSuccess:
-				default:
-					row.Cells.Add (Utils.CreateTableCell ("-"));
-					break;
-				}
-				row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript: editDependencyDownloads ({0}, {1}, \"{2}\")'>{3}</a>", lane.id, dependency.id, string.IsNullOrEmpty (dependency.download_files) ? string.Empty : dependency.download_files.Replace ("\"", "\\\""), string.IsNullOrEmpty (dependency.download_files) ? "(edit)" : HttpUtility.HtmlEncode (dependency.download_files))));
-				row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript: deleteDependency ({0}, {1})'>Delete</a>", lane.id, dependency.id)));
-				tblDependencies.Rows.Add (row);
-			}
-			// Create new dependency row
+		foreach (DBHostLaneView view in response.HostLaneViews) {
+			string ed = view.enabled ? "enabled" : "disabled";
+			string hid = view.hidden ? "hidden" : "visible";
+			string @class = ed + " " + hid;
 			row = new TableRow ();
-			html = "<select id='lstDependentLanes'>";
-			foreach (DBLane l in response.Lanes) {
-				if (l.id == lane.id)
-					continue;
-				html += string.Format ("<option value='{0}'>{1}</option>", l.id, l.lane);
+
+			row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='EditHost.aspx?host_id={0}'>{1}</a>", view.host_id, view.host), @class));
+			html = string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;host_id={1}&amp;action=removeHost'>Remove</a> ", lane.id, view.host_id);
+			html = html + string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;host_id={1}&amp;action=switchHostEnabled'>{2}</a> ", lane.id, view.host_id, (view.enabled ? "Disable" : "Enable"));
+			html = html + string.Format ("<a href='EditLane.aspx?lane_id={0}&amp;host_id={1}&amp;action=switchHostHidden'>{2}</a>", lane.id, view.host_id, (view.hidden ? "Show" : "Hide"));
+			row.Cells.Add (Utils.CreateTableCell (html, @class));
+			tblHosts.Rows.Add (row);
+			current_hosts.Add (view.host);
+		}
+
+		if (response.Hosts.Count != current_hosts.Count) {
+			row = new TableRow ();
+			html = "<select id='lstHosts'>";
+			foreach (DBHost host in response.Hosts) {
+				if (!current_hosts.Contains (host.host))
+					html += "<option value='" + host.id + "'>" + host.host + "</option>";
 			}
 			html += "</select>";
 			row.Cells.Add (Utils.CreateTableCell (html));
-			html = "<select id='lstDependencyConditions'>";
-			foreach (object value in Enum.GetValues (typeof (DBLaneDependencyCondition))) {
-				if ((int) value == 0)
-					continue;
-				html += string.Format ("<option value='{0}'>{1}</option>", (int) value, value.ToString ());
+			row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript:addHost({0})'>Add</a>", lane.id)));
+			tblHosts.Rows.Add (row);
+		}
+
+		// dependencies
+		foreach (DBLaneDependency dependency in response.Dependencies) {
+			row = new TableRow ();
+			for (int i = 0; i < response.Lanes.Count; i++) {
+				if (response.Lanes [i].id == dependency.dependent_lane_id) {
+					row.Cells.Add (Utils.CreateTableCell (response.Lanes [i].lane));
+					break;
+				}
 			}
-			html += "</select>";
-			row.Cells.Add (Utils.CreateTableCell (html));
-			// host
-			html = "<select id='lstDependentHosts'>";
-			html += "<option value='0'>Any</option>";
-			foreach (DBHost h in response.Hosts) {
-				html += string.Format ("<option value='{0}'>{1}</option>", h.id, h.host);
+			row.Cells.Add (Utils.CreateTableCell (dependency.Condition.ToString ()));
+			row.Cells.Add (Utils.CreateTableCell (dependency.dependent_host_id.HasValue ? Utils.FindHost (response.Hosts, dependency.dependent_host_id.Value).host : "Any"));
+			switch (dependency.Condition) {
+			case DBLaneDependencyCondition.DependentLaneSuccessWithFile:
+				row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript: editDependencyFilename ({0}, {1}, \"{2}\")'>{2}</a>", lane.id, dependency.id, string.IsNullOrEmpty (dependency.filename) ? "(edit)" : dependency.filename)));
+				break;
+			case DBLaneDependencyCondition.DependentLaneSuccess:
+			case DBLaneDependencyCondition.DependentLaneIssuesOrSuccess:
+			default:
+				row.Cells.Add (Utils.CreateTableCell ("-"));
+				break;
 			}
-			html += "</select>";
-			row.Cells.Add (Utils.CreateTableCell (html));
-			row.Cells.Add (Utils.CreateTableCell (string.Empty));
-			row.Cells.Add (Utils.CreateTableCell (string.Empty));
-			row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript:addDependency ({0})'>Add</a>", lane.id)));
+			row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript: editDependencyDownloads ({0}, {1}, \"{2}\")'>{3}</a>", lane.id, dependency.id, string.IsNullOrEmpty (dependency.download_files) ? string.Empty : dependency.download_files.Replace ("\"", "\\\""), string.IsNullOrEmpty (dependency.download_files) ? "(edit)" : HttpUtility.HtmlEncode (dependency.download_files))));
+			row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript: deleteDependency ({0}, {1})'>Delete</a>", lane.id, dependency.id)));
 			tblDependencies.Rows.Add (row);
+		}
+		// Create new dependency row
+		row = new TableRow ();
+		html = "<select id='lstDependentLanes'>";
+		foreach (DBLane l in response.Lanes) {
+			if (l.id == lane.id)
+				continue;
+			html += string.Format ("<option value='{0}'>{1}</option>", l.id, l.lane);
+		}
+		html += "</select>";
+		row.Cells.Add (Utils.CreateTableCell (html));
+		html = "<select id='lstDependencyConditions'>";
+		foreach (object value in Enum.GetValues (typeof (DBLaneDependencyCondition))) {
+			if ((int) value == 0)
+				continue;
+			html += string.Format ("<option value='{0}'>{1}</option>", (int) value, value.ToString ());
+		}
+		html += "</select>";
+		row.Cells.Add (Utils.CreateTableCell (html));
+		// host
+		html = "<select id='lstDependentHosts'>";
+		html += "<option value='0'>Any</option>";
+		foreach (DBHost h in response.Hosts) {
+			html += string.Format ("<option value='{0}'>{1}</option>", h.id, h.host);
+		}
+		html += "</select>";
+		row.Cells.Add (Utils.CreateTableCell (html));
+		row.Cells.Add (Utils.CreateTableCell (string.Empty));
+		row.Cells.Add (Utils.CreateTableCell (string.Empty));
+		row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript:addDependency ({0})'>Add</a>", lane.id)));
+		tblDependencies.Rows.Add (row);
 
 //			// deletion directives
 //			foreach (DBLaneDeletionDirectiveView directive in response.LaneDeletionDirectives)
@@ -491,20 +491,17 @@ public partial class EditLane : System.Web.UI.Page
 //			foreach (DBMatchMode mode in Enum.GetValues (typeof (DBMatchMode)))
 //				lstDeletionDirectiveGlobs1.Items.Add (new ListItem (mode.ToString (), ((int) mode).ToString ()));
 
-			editorVariables.Lane = response.Lane;
-			editorVariables.Master = Master;
-			editorVariables.Variables = response.Variables;
+		editorVariables.Lane = response.Lane;
+		editorVariables.Master = Master;
+		editorVariables.Variables = response.Variables;
 
-			// notifications
-			foreach (DBLaneNotification ln in response.LaneNotifications.FindAll ((v) => v.lane_id == response.Lane.id)) {
-				DBNotification notification = response.Notifications.Find ((v) => v.id == ln.notification_id);
-				tblNotifications.Rows.AddAt (tblNotifications.Rows.Count - 1, Utils.CreateTableRow (Utils.CreateTableCell (notification.name), Utils.CreateTableCell (Utils.CreateLinkButton ("remove_notification_" + ln.id.ToString (), "Remove", "RemoveNotification", ln.id.ToString (), OnLinkButtonCommand))));
-			}
-			foreach (DBNotification notification in response.Notifications.FindAll ((v) => !response.LaneNotifications.Exists ((ln) => ln.notification_id == v.id && ln.lane_id == response.Lane.id))) {
-				cmbNotifications.Items.Add (new ListItem (notification.name, notification.id.ToString ()));
-			}
-		} catch (Exception ex) {
-			lblMessage.Text = ex.ToString ().Replace ("\n", "<br/>");
+		// notifications
+		foreach (DBLaneNotification ln in response.LaneNotifications.FindAll ((v) => v.lane_id == response.Lane.id)) {
+			DBNotification notification = response.Notifications.Find ((v) => v.id == ln.notification_id);
+			tblNotifications.Rows.AddAt (tblNotifications.Rows.Count - 1, Utils.CreateTableRow (Utils.CreateTableCell (notification.name), Utils.CreateTableCell (Utils.CreateLinkButton ("remove_notification_" + ln.id.ToString (), "Remove", "RemoveNotification", ln.id.ToString (), OnLinkButtonCommand))));
+		}
+		foreach (DBNotification notification in response.Notifications.FindAll ((v) => !response.LaneNotifications.Exists ((ln) => ln.notification_id == v.id && ln.lane_id == response.Lane.id))) {
+			cmbNotifications.Items.Add (new ListItem (notification.name, notification.id.ToString ()));
 		}
 	}
 
@@ -684,74 +681,46 @@ public partial class EditLane : System.Web.UI.Page
 	protected void lnkAddNotification_Click (object sender, EventArgs e)
 	{
 		WebServiceResponse response;
-
-		try {
-			response = null;
-
-			response = Master.WebService.AddLaneNotification (Master.WebServiceLogin, lane.id, int.Parse (cmbNotifications.SelectedItem.Value));
-			if (response.Exception != null) {
-				lblMessage.Text = response.Exception.Message;
-			} else {
-				RedirectToSelf ();
-			}
-		} catch (Exception ex) {
-			lblMessage.Text = ex.Message;
+		response = Master.WebService.AddLaneNotification (Master.WebServiceLogin, lane.id, int.Parse (cmbNotifications.SelectedItem.Value));
+		if (response.Exception != null) {
+			lblMessage.Text = response.Exception.Message;
+		} else {
+			RedirectToSelf ();
 		}
 	}
 
 	protected void OnLinkButtonCommand (object sender, CommandEventArgs e)
 	{
 		WebServiceResponse response;
-
-		try {
-			switch (e.CommandName) {
-			case "RemoveNotification":
-				response = Master.WebService.RemoveLaneNotification (Master.WebServiceLogin, int.Parse ((string) e.CommandArgument));
-				if (response.Exception != null) {
-					lblMessage.Text = response.Exception.Message;
-				} else {
-					RedirectToSelf ();
-				}
-				break;
+		switch (e.CommandName) {
+		case "RemoveNotification":
+			response = Master.WebService.RemoveLaneNotification (Master.WebServiceLogin, int.Parse ((string) e.CommandArgument));
+			if (response.Exception != null) {
+				lblMessage.Text = response.Exception.Message;
+			} else {
+				RedirectToSelf ();
 			}
-		} catch (Exception ex) {
-			lblMessage.Text = ex.Message;
+			break;
 		}
 	}
 
 	protected void cmdDeleteAllWork_Click (object sender, EventArgs e)
 	{
-		try {
-			Response.Redirect ("Delete.aspx?action=delete-all-work-for-lane&lane_id=" + lane.id.ToString (), false);
-		} catch (Exception ex) {
-			lblMessage.Text = ex.Message;
-		}
+		Response.Redirect ("Delete.aspx?action=delete-all-work-for-lane&lane_id=" + lane.id.ToString (), false);
 	}
 
 	protected void cmdClearAllWork_Click (object sender, EventArgs e)
 	{
-		try {
-			Response.Redirect ("Delete.aspx?action=clear-all-work-for-lane&lane_id=" + lane.id.ToString (), false);
-		} catch (Exception ex) {
-			lblMessage.Text = ex.Message;
-		}
+		Response.Redirect ("Delete.aspx?action=clear-all-work-for-lane&lane_id=" + lane.id.ToString (), false);
 	}
 
 	protected void cmdDeleteAllRevisions_Click (object sender, EventArgs e)
 	{
-		try {
-			Response.Redirect ("Delete.aspx?action=delete-all-revisions-for-lane&lane_id=" + lane.id.ToString (), false);
-		} catch (Exception ex) {
-			lblMessage.Text = ex.Message;
-		}
+		Response.Redirect ("Delete.aspx?action=delete-all-revisions-for-lane&lane_id=" + lane.id.ToString (), false);
 	}
 
 	protected void cmdDontDoWork_Click (object sender, EventArgs e)
 	{
-		try {
-			Master.WebService.MarkAsDontBuild (Master.WebServiceLogin, lane.id);
-		} catch (Exception ex) {
-			lblMessage.Text = ex.Message;
-		}
+		Master.WebService.MarkAsDontBuild (Master.WebServiceLogin, lane.id);
 	}
 }

--- a/MonkeyWrench.Web.UI/EditLaneFile.aspx.cs
+++ b/MonkeyWrench.Web.UI/EditLaneFile.aspx.cs
@@ -60,22 +60,18 @@ public partial class EditLaneFile : System.Web.UI.Page
 	protected void cmdSave_Click (object sender, EventArgs e)
 	{
 		int id;
-		try {
-			if (int.TryParse (Request ["file_id"], out id)) {
-				GetLaneFileForEditResponse response = Master.WebService.GetLaneFileForEdit (Master.WebServiceLogin, id);
-				response.Lanefile.contents = txtEditor.Text;
-				Master.WebService.EditLaneFile (Master.WebServiceLogin, response.Lanefile);
+		if (int.TryParse (Request ["file_id"], out id)) {
+			GetLaneFileForEditResponse response = Master.WebService.GetLaneFileForEdit (Master.WebServiceLogin, id);
+			response.Lanefile.contents = txtEditor.Text;
+			Master.WebService.EditLaneFile (Master.WebServiceLogin, response.Lanefile);
 
-				if (Request.UrlReferrer != null && Request.UrlReferrer.LocalPath.Contains ("ViewLaneFileHistory.aspx")) {
-					Response.Redirect ("ViewLaneFileHistory.aspx?id=" + Request ["file_id"], false);
-				} else {
-					Response.Redirect ("EditLane.aspx?lane_id=" + Request ["lane_id"], false);
-				}
+			if (Request.UrlReferrer != null && Request.UrlReferrer.LocalPath.Contains ("ViewLaneFileHistory.aspx")) {
+				Response.Redirect ("ViewLaneFileHistory.aspx?id=" + Request ["file_id"], false);
 			} else {
 				Response.Redirect ("EditLane.aspx?lane_id=" + Request ["lane_id"], false);
 			}
-		} catch (Exception ex) {
-			Response.Write (ex.ToString ().Replace ("\n", "<br/>"));
+		} else {
+			Response.Redirect ("EditLane.aspx?lane_id=" + Request ["lane_id"], false);
 		}
 	}
 }

--- a/MonkeyWrench.Web.UI/EditLanes.aspx.cs
+++ b/MonkeyWrench.Web.UI/EditLanes.aspx.cs
@@ -69,13 +69,9 @@ public partial class EditLanes : System.Web.UI.Page
 				}
 			}
 		} else if (!string.IsNullOrEmpty (Request ["txtLane"])) {
-			try {
-				Master.WebService.AddLane (Master.WebServiceLogin, Request ["txtlane"]);
-				Response.Redirect ("EditLanes.aspx", false);
-				return;
-			} catch (Exception ex) {
-				lblMessage.Text = Utils.FormatException (ex);
-			}
+			Master.WebService.AddLane (Master.WebServiceLogin, Request ["txtlane"]);
+			Response.Redirect ("EditLanes.aspx", false);
+			return;
 		}
 
 		GetLanesResponse response = Master.WebService.GetLanes (Master.WebServiceLogin);

--- a/MonkeyWrench.Web.UI/GetRevisionLog.aspx.cs
+++ b/MonkeyWrench.Web.UI/GetRevisionLog.aspx.cs
@@ -37,25 +37,17 @@ public partial class GetRevisionLog : System.Web.UI.Page
 		string d, l;
 
 		if (revision_id != null) {
-			try {
-				l = WebServices.DownloadString (WebServices.CreateWebServiceDownloadRevisionUrl (revision_id.Value, false, Master.WebServiceLogin));
-				if (raw) {
-					log.InnerHtml = "<pre>" + HttpUtility.HtmlEncode (l) + "</pre>";
-				} else {
-					log.InnerHtml = "<div style='background-color: #ccccff; padding: 5px; margin-top: 5px; margin-bottom: 5px;'><pre style='border-width: 0px;'>" + HttpUtility.HtmlEncode (l) + "</pre></div>";
-				}
-			} catch (Exception ex) {
-				log.InnerText = "Exception while fetching log: " + ex.ToString ();
+			l = WebServices.DownloadString (WebServices.CreateWebServiceDownloadRevisionUrl (revision_id.Value, false, Master.WebServiceLogin));
+			if (raw) {
+				log.InnerHtml = "<pre>" + HttpUtility.HtmlEncode (l) + "</pre>";
+			} else {
+				log.InnerHtml = "<div style='background-color: #ccccff; padding: 5px; margin-top: 5px; margin-bottom: 5px;'><pre style='border-width: 0px;'>" + HttpUtility.HtmlEncode (l) + "</pre></div>";
 			}
-			try {
-				d = WebServices.DownloadString (WebServices.CreateWebServiceDownloadRevisionUrl (revision_id.Value, true, Master.WebServiceLogin));
-				if (raw) {
-					diff.InnerHtml = "<pre>" + HttpUtility.HtmlEncode (d) + "</pre>";
-				} else {
-					diff.InnerHtml = ParseDiff (d);
-				}
-			} catch (Exception ex) {
-				diff.InnerText = "Exception while fetching diff: " + ex.ToString ();
+			d = WebServices.DownloadString (WebServices.CreateWebServiceDownloadRevisionUrl (revision_id.Value, true, Master.WebServiceLogin));
+			if (raw) {
+				diff.InnerHtml = "<pre>" + HttpUtility.HtmlEncode (d) + "</pre>";
+			} else {
+				diff.InnerHtml = ParseDiff (d);
 			}
 		}
 	}

--- a/MonkeyWrench.Web.UI/GetStatus.aspx.cs
+++ b/MonkeyWrench.Web.UI/GetStatus.aspx.cs
@@ -62,9 +62,6 @@ namespace MonkeyWrench.Web.UI
 			} catch (HttpException exp) {
 				Response.StatusCode = exp.GetHttpCode ();
 				Response.Write (exp.Message);
-			} catch (Exception exp) {
-				Response.StatusCode = 500;
-				Response.Write ("{\"error\": \"" + exp.Message.Replace ("\"", "\\\"") + "\"}");
 			} finally {
 				Response.Flush ();
 				Response.Close ();

--- a/MonkeyWrench.Web.UI/Global.asax.cs
+++ b/MonkeyWrench.Web.UI/Global.asax.cs
@@ -53,7 +53,23 @@ namespace MonkeyWrench.Web.UI
 				Response.Write (HttpUtility.HtmlEncode (ex.ToString ()));
 				Response.Write ("</pre>");
 			} else {
-				Response.Write ("<h1>Wrench encountered an error.</h1><p>We're sorry about that. The error has been logged, and will hopefully be fixed soon!</p>");
+				var httpex = ex as HttpUnhandledException;
+				if (httpex != null)
+					ex = httpex.InnerException;
+
+				Response.Write (String.Format (@"
+					<!DOCTYPE html>
+					<html>
+					<head>
+						<title>500 - Internal Server Error</title>
+					</head>
+					<body>
+					<h1>Wrench encountered an error.</h1>
+					<p>We're sorry about that. The error has been logged, and will hopefully be fixed soon!</p>
+					<p>Error summary: <samp>{0}: {1}</samp></p>
+					</body>
+					</html>
+				", HttpUtility.HtmlEncode (ex.GetType().Name), HttpUtility.HtmlEncode (ex.Message)));
 			}
 			Server.ClearError ();
 		}

--- a/MonkeyWrench.Web.UI/Global.asax.cs
+++ b/MonkeyWrench.Web.UI/Global.asax.cs
@@ -43,7 +43,19 @@ namespace MonkeyWrench.Web.UI
 
 		protected void Application_Error (object sender, EventArgs e)
 		{
+			Exception ex = Server.GetLastError ();
+			Logger.Log ("{0}: {1}", Request.Url.AbsoluteUri, ex);
 
+			Response.StatusCode = 500;
+
+			if (Request.IsLocal) {
+				Response.Write ("<pre>");
+				Response.Write (HttpUtility.HtmlEncode (ex.ToString ()));
+				Response.Write ("</pre>");
+			} else {
+				Response.Write ("<h1>Wrench encountered an error.</h1><p>We're sorry about that. The error has been logged, and will hopefully be fixed soon!</p>");
+			}
+			Server.ClearError ();
 		}
 
 		protected void Session_End (object sender, EventArgs e)

--- a/MonkeyWrench.Web.UI/Identities.aspx.cs
+++ b/MonkeyWrench.Web.UI/Identities.aspx.cs
@@ -34,157 +34,152 @@ public partial class Identities : System.Web.UI.Page
 	{
 		GetIdentitiesResponse response;
 		TableRow row;
+		string action = Request ["action"];
+		int id;
 
-		try {
-			string action = Request ["action"];
-			int id;
+		foreach (TextBox tb in new TextBox [] { txtEmailEmail, txtEmailName, txtEmailPassword }) {
+			tb.Attributes.Add ("onfocus", "javascript: document.getElementById ('lblEmailHelp').innerHTML = '" + tb.ToolTip + "';");
+		}
 
-			foreach (TextBox tb in new TextBox [] { txtEmailEmail, txtEmailName, txtEmailPassword }) {
-				tb.Attributes.Add ("onfocus", "javascript: document.getElementById ('lblEmailHelp').innerHTML = '" + tb.ToolTip + "';");
-			}
+		foreach (TextBox tb in new TextBox [] { txtIrcChannels, txtIrcName, txtIrcNicks, txtIrcServers}) {
+			tb.Attributes.Add ("onfocus", "javascript: document.getElementById ('lblIrcHelp').innerHTML = '" + tb.ToolTip + "';");
+		}
+		
+		response = Master.WebService.GetIdentities (Master.WebServiceLogin);
 
-			foreach (TextBox tb in new TextBox [] { txtIrcChannels, txtIrcName, txtIrcNicks, txtIrcServers}) {
-				tb.Attributes.Add ("onfocus", "javascript: document.getElementById ('lblIrcHelp').innerHTML = '" + tb.ToolTip + "';");
-			}
-			
-			response = Master.WebService.GetIdentities (Master.WebServiceLogin);
+		if (response.Exception != null) {
+			lblMessage.Text = response.Exception.Message;
+		} else {
+			if (!string.IsNullOrEmpty (action)) {
+				WebServiceResponse rsp;
 
-			if (response.Exception != null) {
-				lblMessage.Text = response.Exception.Message;
-			} else {
-				if (!string.IsNullOrEmpty (action)) {
-					WebServiceResponse rsp;
-
-					switch (action) {
-					case "changeircname":
-						string name = Request ["name"];
-						if (!string.IsNullOrEmpty (name) && int.TryParse (Request ["id"], out id)) {
-							DBIrcIdentity identity = response.IrcIdentities.Find ((v1) => v1.id == id);
-							if (identity != null) {
-								identity.name = name;
-								rsp = Master.WebService.EditIdentity (Master.WebServiceLogin, identity, null);
-								if (rsp.Exception != null) {
-									lblMessage.Text = response.Exception.Message;
-									return;
-								}
+				switch (action) {
+				case "changeircname":
+					string name = Request ["name"];
+					if (!string.IsNullOrEmpty (name) && int.TryParse (Request ["id"], out id)) {
+						DBIrcIdentity identity = response.IrcIdentities.Find ((v1) => v1.id == id);
+						if (identity != null) {
+							identity.name = name;
+							rsp = Master.WebService.EditIdentity (Master.WebServiceLogin, identity, null);
+							if (rsp.Exception != null) {
+								lblMessage.Text = response.Exception.Message;
+								return;
 							}
 						}
-						break;
-					case "switchircssl":
-						if (int.TryParse (Request ["id"], out id)) {
-							DBIrcIdentity identity = response.IrcIdentities.Find ((v2) => v2.id == id);
-							if (identity != null) {
-								identity.use_ssl = !identity.use_ssl;
-								rsp = Master.WebService.EditIdentity (Master.WebServiceLogin, identity, null);
-								if (rsp.Exception != null) {
-									lblMessage.Text = response.Exception.Message;
-									return;
-								}
-							}
-						}
-						break;
-					case "changeircchannels":
-						string channels = Request ["channels"];
-						if (!string.IsNullOrEmpty (channels) && int.TryParse (Request ["id"], out id)) {
-							DBIrcIdentity identity = response.IrcIdentities.Find ((v3) => v3.id == id);
-							if (identity != null) {
-								identity.channels = channels;
-								rsp = Master.WebService.EditIdentity (Master.WebServiceLogin, identity, null);
-								if (rsp.Exception != null) {
-									lblMessage.Text = response.Exception.Message;
-									return;
-								}
-							}
-						}
-						break;
-					case "switchjoinchannels":
-						if (int.TryParse (Request ["id"], out id)) {
-							DBIrcIdentity identity = response.IrcIdentities.Find ((v4) => v4.id == id);
-							if (identity != null) {
-								identity.join_channels = !identity.join_channels;
-								rsp = Master.WebService.EditIdentity (Master.WebServiceLogin, identity, null);
-								if (rsp.Exception != null) {
-									lblMessage.Text = response.Exception.Message;
-									return;
-								}
-							}
-						}
-						break;
-					case "changeircnicks":
-						string nicks = Request ["nicks"];
-						if (!string.IsNullOrEmpty (nicks) && int.TryParse (Request ["id"], out id)) {
-							DBIrcIdentity identity = response.IrcIdentities.Find ((v5) => v5.id == id);
-							if (identity != null) {
-								identity.nicks = nicks;
-								rsp = Master.WebService.EditIdentity (Master.WebServiceLogin, identity, null);
-								if (rsp.Exception != null) {
-									lblMessage.Text = response.Exception.Message;
-									return;
-								}
-							}
-						}
-						break;
-					case "changeircservers":
-						string servers = Request ["servers"];
-						if (!string.IsNullOrEmpty (servers) && int.TryParse (Request ["id"], out id)) {
-							DBIrcIdentity identity = response.IrcIdentities.Find ((v6) => v6.id == id);
-							if (identity != null) {
-								identity.servers = servers;
-								rsp = Master.WebService.EditIdentity (Master.WebServiceLogin, identity, null);
-								if (rsp.Exception != null) {
-									lblMessage.Text = response.Exception.Message;
-									return;
-								}
-							}
-						}
-						break;
-					case "changeircpassword":
-						string password = Request ["password"];
-						if (int.TryParse (Request ["id"], out id)) {
-							DBIrcIdentity identity = response.IrcIdentities.Find ((v6) => v6.id == id);
-							if (identity != null) {
-								identity.password = password;
-								rsp = Master.WebService.EditIdentity (Master.WebServiceLogin, identity, null);
-								if (rsp.Exception != null) {
-									lblMessage.Text = response.Exception.Message;
-									return;
-								}
-							}
-						}
-						break;
 					}
-
-					Response.Redirect ("Identities.aspx", false);
-					return;
+					break;
+				case "switchircssl":
+					if (int.TryParse (Request ["id"], out id)) {
+						DBIrcIdentity identity = response.IrcIdentities.Find ((v2) => v2.id == id);
+						if (identity != null) {
+							identity.use_ssl = !identity.use_ssl;
+							rsp = Master.WebService.EditIdentity (Master.WebServiceLogin, identity, null);
+							if (rsp.Exception != null) {
+								lblMessage.Text = response.Exception.Message;
+								return;
+							}
+						}
+					}
+					break;
+				case "changeircchannels":
+					string channels = Request ["channels"];
+					if (!string.IsNullOrEmpty (channels) && int.TryParse (Request ["id"], out id)) {
+						DBIrcIdentity identity = response.IrcIdentities.Find ((v3) => v3.id == id);
+						if (identity != null) {
+							identity.channels = channels;
+							rsp = Master.WebService.EditIdentity (Master.WebServiceLogin, identity, null);
+							if (rsp.Exception != null) {
+								lblMessage.Text = response.Exception.Message;
+								return;
+							}
+						}
+					}
+					break;
+				case "switchjoinchannels":
+					if (int.TryParse (Request ["id"], out id)) {
+						DBIrcIdentity identity = response.IrcIdentities.Find ((v4) => v4.id == id);
+						if (identity != null) {
+							identity.join_channels = !identity.join_channels;
+							rsp = Master.WebService.EditIdentity (Master.WebServiceLogin, identity, null);
+							if (rsp.Exception != null) {
+								lblMessage.Text = response.Exception.Message;
+								return;
+							}
+						}
+					}
+					break;
+				case "changeircnicks":
+					string nicks = Request ["nicks"];
+					if (!string.IsNullOrEmpty (nicks) && int.TryParse (Request ["id"], out id)) {
+						DBIrcIdentity identity = response.IrcIdentities.Find ((v5) => v5.id == id);
+						if (identity != null) {
+							identity.nicks = nicks;
+							rsp = Master.WebService.EditIdentity (Master.WebServiceLogin, identity, null);
+							if (rsp.Exception != null) {
+								lblMessage.Text = response.Exception.Message;
+								return;
+							}
+						}
+					}
+					break;
+				case "changeircservers":
+					string servers = Request ["servers"];
+					if (!string.IsNullOrEmpty (servers) && int.TryParse (Request ["id"], out id)) {
+						DBIrcIdentity identity = response.IrcIdentities.Find ((v6) => v6.id == id);
+						if (identity != null) {
+							identity.servers = servers;
+							rsp = Master.WebService.EditIdentity (Master.WebServiceLogin, identity, null);
+							if (rsp.Exception != null) {
+								lblMessage.Text = response.Exception.Message;
+								return;
+							}
+						}
+					}
+					break;
+				case "changeircpassword":
+					string password = Request ["password"];
+					if (int.TryParse (Request ["id"], out id)) {
+						DBIrcIdentity identity = response.IrcIdentities.Find ((v6) => v6.id == id);
+						if (identity != null) {
+							identity.password = password;
+							rsp = Master.WebService.EditIdentity (Master.WebServiceLogin, identity, null);
+							if (rsp.Exception != null) {
+								lblMessage.Text = response.Exception.Message;
+								return;
+							}
+						}
+					}
+					break;
 				}
 
-				if (response.IrcIdentities != null) {
-					foreach (DBIrcIdentity irc in response.IrcIdentities) {
-						row = new TableRow ();
-						row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript:changeircname ({2}, \"{0}\");'>{1}</a>", HttpUtility.UrlEncode (irc.name), HttpUtility.HtmlEncode (irc.name), irc.id)));
-						row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript:changeircservers ({2}, \"{0}\");'>{1}</a>", HttpUtility.UrlEncode (irc.servers), HttpUtility.HtmlEncode (irc.servers), irc.id)));
-						row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript:changeircpassword ({2}, \"{0}\");'>{1}</a>", HttpUtility.UrlEncode (irc.password), string.IsNullOrEmpty (irc.password) ? "(none)" : HttpUtility.HtmlEncode (irc.password), irc.id)));
-						row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='Identities.aspx?action=switchircssl&id={1}'>{0}</a>", irc.use_ssl ? "Yes" : "No", irc.id)));
-						row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript:changeircchannels ({2}, \"{0}\");'>{1}</a>", HttpUtility.UrlEncode (irc.channels), HttpUtility.HtmlEncode (irc.channels), irc.id)));
-						row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='Identities.aspx?action=switchjoinchannels&id={1}'>{0}</a>", irc.join_channels ? "Yes" : "No", irc.id)));
-						row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript:changeircnicks ({2}, \"{0}\");'>{1}</a>", HttpUtility.UrlEncode (irc.nicks), HttpUtility.HtmlEncode (irc.nicks), irc.id)));
-						row.Cells.Add (Utils.CreateTableCell (Utils.CreateLinkButton ("remove_irc_" + irc.id.ToString (), "Remove", "RemoveIrcIdentity", irc.id.ToString (), OnLinkButtonCommand)));
-						tblIrcIdentities.Rows.AddAt (tblIrcIdentities.Rows.Count - 1, row);
-					}
-				}
-				if (response.EmailIdentities != null) {
-					foreach (DBEmailIdentity email in response.EmailIdentities) {
-						row = new TableRow ();
-						row.Cells.Add (Utils.CreateTableCell (email.name));
-						row.Cells.Add (Utils.CreateTableCell (email.email));
-						row.Cells.Add (Utils.CreateTableCell (email.password));
-						row.Cells.Add (Utils.CreateTableCell (Utils.CreateLinkButton ("remove_email_" + email.id.ToString (), "Remove", "RemoveEmailIdentity", email.id.ToString (), OnLinkButtonCommand)));
-						tblEmailIdentities.Rows.AddAt (tblEmailIdentities.Rows.Count - 1, row);
-					}
+				Response.Redirect ("Identities.aspx", false);
+				return;
+			}
+
+			if (response.IrcIdentities != null) {
+				foreach (DBIrcIdentity irc in response.IrcIdentities) {
+					row = new TableRow ();
+					row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript:changeircname ({2}, \"{0}\");'>{1}</a>", HttpUtility.UrlEncode (irc.name), HttpUtility.HtmlEncode (irc.name), irc.id)));
+					row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript:changeircservers ({2}, \"{0}\");'>{1}</a>", HttpUtility.UrlEncode (irc.servers), HttpUtility.HtmlEncode (irc.servers), irc.id)));
+					row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript:changeircpassword ({2}, \"{0}\");'>{1}</a>", HttpUtility.UrlEncode (irc.password), string.IsNullOrEmpty (irc.password) ? "(none)" : HttpUtility.HtmlEncode (irc.password), irc.id)));
+					row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='Identities.aspx?action=switchircssl&id={1}'>{0}</a>", irc.use_ssl ? "Yes" : "No", irc.id)));
+					row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript:changeircchannels ({2}, \"{0}\");'>{1}</a>", HttpUtility.UrlEncode (irc.channels), HttpUtility.HtmlEncode (irc.channels), irc.id)));
+					row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='Identities.aspx?action=switchjoinchannels&id={1}'>{0}</a>", irc.join_channels ? "Yes" : "No", irc.id)));
+					row.Cells.Add (Utils.CreateTableCell (string.Format ("<a href='javascript:changeircnicks ({2}, \"{0}\");'>{1}</a>", HttpUtility.UrlEncode (irc.nicks), HttpUtility.HtmlEncode (irc.nicks), irc.id)));
+					row.Cells.Add (Utils.CreateTableCell (Utils.CreateLinkButton ("remove_irc_" + irc.id.ToString (), "Remove", "RemoveIrcIdentity", irc.id.ToString (), OnLinkButtonCommand)));
+					tblIrcIdentities.Rows.AddAt (tblIrcIdentities.Rows.Count - 1, row);
 				}
 			}
-		} catch (Exception ex) {
-			lblMessage.Text = ex.Message;
+			if (response.EmailIdentities != null) {
+				foreach (DBEmailIdentity email in response.EmailIdentities) {
+					row = new TableRow ();
+					row.Cells.Add (Utils.CreateTableCell (email.name));
+					row.Cells.Add (Utils.CreateTableCell (email.email));
+					row.Cells.Add (Utils.CreateTableCell (email.password));
+					row.Cells.Add (Utils.CreateTableCell (Utils.CreateLinkButton ("remove_email_" + email.id.ToString (), "Remove", "RemoveEmailIdentity", email.id.ToString (), OnLinkButtonCommand)));
+					tblEmailIdentities.Rows.AddAt (tblEmailIdentities.Rows.Count - 1, row);
+				}
+			}
 		}
 	}
 
@@ -192,24 +187,20 @@ public partial class Identities : System.Web.UI.Page
 	{
 		WebServiceResponse response = null;
 
-		try {
-			switch (e.CommandName) {
-			case "RemoveIrcIdentity":
-				response = Master.WebService.RemoveIdentity (Master.WebServiceLogin, int.Parse ((string) e.CommandArgument), null);
-				break;
-			case "RemoveEmailIdentity":
-				response = Master.WebService.RemoveIdentity (Master.WebServiceLogin, null, int.Parse ((string) e.CommandArgument));
-				break;
+		switch (e.CommandName) {
+		case "RemoveIrcIdentity":
+			response = Master.WebService.RemoveIdentity (Master.WebServiceLogin, int.Parse ((string) e.CommandArgument), null);
+			break;
+		case "RemoveEmailIdentity":
+			response = Master.WebService.RemoveIdentity (Master.WebServiceLogin, null, int.Parse ((string) e.CommandArgument));
+			break;
+		}
+		if (response != null) {
+			if (response.Exception != null) {
+				lblMessage.Text = response.Exception.Message;
+			} else {
+				Response.Redirect ("Identities.aspx", false);
 			}
-			if (response != null) {
-				if (response.Exception != null) {
-					lblMessage.Text = response.Exception.Message;
-				} else {
-					Response.Redirect ("Identities.aspx", false);
-				}
-			}
-		} catch (Exception ex) {
-			lblMessage.Text = ex.Message;
 		}
 	}
 
@@ -217,34 +208,35 @@ public partial class Identities : System.Web.UI.Page
 	{
 		WebServiceResponse response;
 
+		DBIrcIdentity irc_identity = new DBIrcIdentity ();
+		irc_identity.name = txtIrcName.Text;
+		irc_identity.nicks = txtIrcNicks.Text;
+		irc_identity.servers = txtIrcServers.Text;
+		irc_identity.join_channels = chkJoinChannels.Checked;
+		irc_identity.use_ssl = chkUseSsl.Checked;
+		irc_identity.channels = txtIrcChannels.Text;
+		irc_identity.password = txtPassword.Text ?? string.Empty;
+
 		try {
-			DBIrcIdentity irc_identity = new DBIrcIdentity ();
-			irc_identity.name = txtIrcName.Text;
-			irc_identity.nicks = txtIrcNicks.Text;
-			irc_identity.servers = txtIrcServers.Text;
-			irc_identity.join_channels = chkJoinChannels.Checked;
-			irc_identity.use_ssl = chkUseSsl.Checked;
-			irc_identity.channels = txtIrcChannels.Text;
-			irc_identity.password = txtPassword.Text ?? string.Empty;
-
 			if (string.IsNullOrEmpty (irc_identity.name))
-				throw new Exception ("You need to specify the name of the irc identity");
+				throw new ValidationException ("You need to specify the name of the irc identity");
 			if (string.IsNullOrEmpty (irc_identity.nicks))
-				throw new Exception ("You need to specify the nick names to use for the irc identity");
+				throw new ValidationException ("You need to specify the nick names to use for the irc identity");
 			if (string.IsNullOrEmpty (irc_identity.servers))
-				throw new Exception ("You need to specify the servers to use for the irc identity");
+				throw new ValidationException ("You need to specify the servers to use for the irc identity");
 			if (string.IsNullOrEmpty (irc_identity.channels))
-				throw new Exception ("You need to specify the channels to join for the irc identity");
-
-			response = Master.WebService.EditIdentity (Master.WebServiceLogin, irc_identity, null);
-
-			if (response.Exception != null) {
-				lblMessage.Text = response.Exception.Message;
-			} else {
-				Response.Redirect ("Identities.aspx", false);
-			}
-		} catch (Exception ex) {
+				throw new ValidationException ("You need to specify the channels to join for the irc identity");
+		} catch(ValidationException ex) {
 			lblMessage.Text = ex.Message;
+			return;
+		}
+
+		response = Master.WebService.EditIdentity (Master.WebServiceLogin, irc_identity, null);
+
+		if (response.Exception != null) {
+			lblMessage.Text = response.Exception.Message;
+		} else {
+			Response.Redirect ("Identities.aspx", false);
 		}
 	}
 
@@ -252,29 +244,29 @@ public partial class Identities : System.Web.UI.Page
 	{
 		WebServiceResponse response;
 
+		DBEmailIdentity email_identity = new DBEmailIdentity ();
+		email_identity.name = txtEmailName.Text;
+		email_identity.email = txtEmailEmail.Text;
+		email_identity.password = txtEmailPassword.Text;
+
 		try {
-			DBEmailIdentity email_identity = new DBEmailIdentity ();
-			email_identity.name = txtEmailName.Text;
-			email_identity.email = txtEmailEmail.Text;
-			email_identity.password = txtEmailPassword.Text;
-
-
 			if (string.IsNullOrEmpty (email_identity.name))
-				throw new Exception ("You need to specify the name of the email identity");
+				throw new ValidationException ("You need to specify the name of the email identity");
 			if (string.IsNullOrEmpty (email_identity.email))
-				throw new Exception ("You need to specify the email for the email identity");
+				throw new ValidationException ("You need to specify the email for the email identity");
 			if (string.IsNullOrEmpty (email_identity.password))
-				throw new Exception ("You need to specify the password for the email identity");
-
-			response = Master.WebService.EditIdentity (Master.WebServiceLogin, null, email_identity);
-
-			if (response.Exception != null) {
-				lblMessage.Text = response.Exception.Message;
-			} else {
-				Response.Redirect ("Identities.aspx", false);
-			}
-		} catch (Exception ex) {
+				throw new ValidationException ("You need to specify the password for the email identity");
+		} catch(ValidationException ex) {
 			lblMessage.Text = ex.Message;
+			return;
+		}
+
+		response = Master.WebService.EditIdentity (Master.WebServiceLogin, null, email_identity);
+
+		if (response.Exception != null) {
+			lblMessage.Text = response.Exception.Message;
+		} else {
+			Response.Redirect ("Identities.aspx", false);
 		}
 	}
 }

--- a/MonkeyWrench.Web.UI/Login.aspx.cs
+++ b/MonkeyWrench.Web.UI/Login.aspx.cs
@@ -73,22 +73,18 @@ public partial class Login : System.Web.UI.Page
 					var fetch = oidresponse.GetExtension<FetchResponse> ();
 					string email;
 
-					try {
-						email = fetch.Attributes [WellKnownAttributes.Contact.Email].Values [0];
+					email = fetch.Attributes [WellKnownAttributes.Contact.Email].Values [0];
 
-						WebServiceLogin login = new WebServiceLogin ();
-						login.Password = Configuration.WebServicePassword;
-						login.User = Configuration.Host;
-						var response = Master.WebService.LoginOpenId (login, email, Utilities.GetExternalIP (Request));
-						if (response.Exception != null) {
-							lblMessageOpenId.Text = response.Exception.Message;
-						} else {
-							Authentication.SetCookies (Response, response);
-							Response.Redirect (txtReferrer.Value, false);
-							return;
-						}
-					} catch (Exception ex) {
-						lblMessageOpenId.Text = Utils.FormatException (ex);
+					WebServiceLogin login = new WebServiceLogin ();
+					login.Password = Configuration.WebServicePassword;
+					login.User = Configuration.Host;
+					var response = Master.WebService.LoginOpenId (login, email, Utilities.GetExternalIP (Request));
+					if (response.Exception != null) {
+						lblMessageOpenId.Text = response.Exception.Message;
+					} else {
+						Authentication.SetCookies (Response, response);
+						Response.Redirect (txtReferrer.Value, false);
+						return;
 					}
 					break;
 				default:
@@ -134,16 +130,11 @@ public partial class Login : System.Web.UI.Page
 	{
 		Master.ClearLogin ();
 
-		try {
-			if (!Authentication.Login (txtUser.Text, txtPassword.Text, Request, Response)) {
-				lblMessage.Text = "Could not log in";
-				txtPassword.Text = "";
-			} else {
-				Response.Redirect (txtReferrer.Value, false);
-			}
-		} catch (Exception) {
-			lblMessage.Text = "Invalid user/password.";
+		if (!Authentication.Login (txtUser.Text, txtPassword.Text, Request, Response)) {
+			lblMessage.Text = "Could not log in";
 			txtPassword.Text = "";
+		} else {
+			Response.Redirect (txtReferrer.Value, false);
 		}
 	}
 

--- a/MonkeyWrench.Web.UI/Master.master.cs
+++ b/MonkeyWrench.Web.UI/Master.master.cs
@@ -86,11 +86,7 @@ public partial class Master : System.Web.UI.MasterPage
 			adminmenu.Visible = true;
 		}
 
-		try {
-			tree_response = Utils.LocalWebService.GetLeftTreeData (WebServiceLogin);
-		} catch {
-			tree_response = null;
-		}
+		tree_response = Utils.LocalWebService.GetLeftTreeData (WebServiceLogin);
 
 		CreateTree ();
 		CreateHostStatus ();
@@ -159,40 +155,35 @@ public partial class Master : System.Web.UI.MasterPage
 		LaneTreeNode root;
 		Panel div;
 
-		try {
-			var response = tree_response;
+		var response = tree_response;
 
-			// Remove disabled lanes.
-			var lanes = new List<DBLane> (response.Lanes);
-			for (int i = lanes.Count -1; i >= 0; i--) {
-				if (lanes [i].enabled)
-					continue;
-				lanes.RemoveAt (i);
-			}
-			root = LaneTreeNode.BuildTree (lanes, null);
-
-			SetResponse (response);
-
-			// layout the tree
-			div = new Panel ();
-			div.ID = "tree_root_id";
-
-			tableMainTree.Rows.Add (Utils.CreateTableRow (CreateTreeViewRow ("index.aspx?show_all=true", "All", 0, root.Depth, true, div, true)));
-
-			tableMainTree.Rows.Add (Utils.CreateTableRow (div));
-			WriteTree (root, tableMainTree, 1, root.Depth, div);
-
-			// layout the tags
-			div = new Panel ();
-			div.ID = "tags_root_id";
-
-			tableMainTree.Rows.Add (Utils.CreateTableRow (CreateTreeViewRow (null, "Tags", 0, 1, true, div, true)));
-			tableMainTree.Rows.Add (Utils.CreateTableRow (div));
-			WriteTags (response.Tags, tableMainTree, 1, div);
-
-		} catch {
-			tableMainTree.Visible = false;
+		// Remove disabled lanes.
+		var lanes = new List<DBLane> (response.Lanes);
+		for (int i = lanes.Count -1; i >= 0; i--) {
+			if (lanes [i].enabled)
+				continue;
+			lanes.RemoveAt (i);
 		}
+		root = LaneTreeNode.BuildTree (lanes, null);
+
+		SetResponse (response);
+
+		// layout the tree
+		div = new Panel ();
+		div.ID = "tree_root_id";
+
+		tableMainTree.Rows.Add (Utils.CreateTableRow (CreateTreeViewRow ("index.aspx?show_all=true", "All", 0, root.Depth, true, div, true)));
+
+		tableMainTree.Rows.Add (Utils.CreateTableRow (div));
+		WriteTree (root, tableMainTree, 1, root.Depth, div);
+
+		// layout the tags
+		div = new Panel ();
+		div.ID = "tags_root_id";
+
+		tableMainTree.Rows.Add (Utils.CreateTableRow (CreateTreeViewRow (null, "Tags", 0, 1, true, div, true)));
+		tableMainTree.Rows.Add (Utils.CreateTableRow (div));
+		WriteTags (response.Tags, tableMainTree, 1, div);
 	}
 
 	public void WriteTags (List<string> tags, Table tableMain, int level, Panel containing_div)

--- a/MonkeyWrench.Web.UI/Notifications.aspx.cs
+++ b/MonkeyWrench.Web.UI/Notifications.aspx.cs
@@ -38,50 +38,45 @@ public partial class Notifications : System.Web.UI.Page
 		TableRow row;
 		GetNotificationsResponse response;
 
-		try {
+		foreach (WebControl tb in new WebControl [] { txtName, cmbIdentity, cmbMode, cmbNotificationType }) {
+			tb.Attributes.Add ("onfocus", "javascript: document.getElementById ('lblHelp').innerHTML = '" + tb.ToolTip.Replace ("'", "\\'").Replace ("\n", "<br/>").Replace ("\r", "<br />") + "';");
+		}
 
-			foreach (WebControl tb in new WebControl [] { txtName, cmbIdentity, cmbMode, cmbNotificationType }) {
-				tb.Attributes.Add ("onfocus", "javascript: document.getElementById ('lblHelp').innerHTML = '" + tb.ToolTip.Replace ("'", "\\'").Replace ("\n", "<br/>").Replace ("\r", "<br />") + "';");
-			}
+		response = Master.WebService.GetNotifications (Master.WebServiceLogin);
 
-			response = Master.WebService.GetNotifications (Master.WebServiceLogin);
-
-			if (response.Exception != null) {
-				lblMessage.Text = response.Exception.Message;
-			} else {
-				if (response.IrcIdentities != null) {
-					foreach (DBIrcIdentity irc in response.IrcIdentities) {
-						cmbIdentity.Items.Add (new ListItem ("IRC: " + irc.name, irc.id.ToString ()));
-					}
-				}
-				if (response.EmailIdentities != null) {
-					foreach (DBEmailIdentity email in response.EmailIdentities) {
-						cmbIdentity.Items.Add (new ListItem ("Email: " + email.name, email.id.ToString ()));
-					}
-				}
-				if (response.Notifications != null) {
-					foreach (DBNotification notification in response.Notifications) {
-						row = new TableRow ();
-						row.Cells.Add (Utils.CreateTableCell (notification.name));
-						if (notification.ircidentity_id.HasValue) {
-							row.Cells.Add (Utils.CreateTableCell (response.IrcIdentities.Find ((v) => v.id == notification.ircidentity_id.Value).name));
-							row.Cells.Add (Utils.CreateTableCell ("IRC"));
-						} else if (notification.emailidentity_id.HasValue) {
-							row.Cells.Add (Utils.CreateTableCell (response.EmailIdentities.Find ((v) => v.id == notification.emailidentity_id.Value).name));
-							row.Cells.Add (Utils.CreateTableCell ("Email"));
-						} else {
-							row.Cells.Add (Utils.CreateTableCell ("?"));
-							row.Cells.Add (Utils.CreateTableCell ("?"));
-						}
-						row.Cells.Add (Utils.CreateTableCell (cmbMode.Items [notification.mode].Text));
-						row.Cells.Add (Utils.CreateTableCell (cmbNotificationType.Items [notification.type].Text));
-						row.Cells.Add (Utils.CreateTableCell (Utils.CreateLinkButton ("remove_notification_" + notification.id.ToString (), "Remove", "RemoveNotification", notification.id.ToString (), OnLinkButtonCommand)));
-						tblNotifications.Rows.AddAt (tblNotifications.Rows.Count - 1, row);
-					}
+		if (response.Exception != null) {
+			lblMessage.Text = response.Exception.Message;
+		} else {
+			if (response.IrcIdentities != null) {
+				foreach (DBIrcIdentity irc in response.IrcIdentities) {
+					cmbIdentity.Items.Add (new ListItem ("IRC: " + irc.name, irc.id.ToString ()));
 				}
 			}
-		} catch (Exception ex) {
-			lblMessage.Text = ex.Message;
+			if (response.EmailIdentities != null) {
+				foreach (DBEmailIdentity email in response.EmailIdentities) {
+					cmbIdentity.Items.Add (new ListItem ("Email: " + email.name, email.id.ToString ()));
+				}
+			}
+			if (response.Notifications != null) {
+				foreach (DBNotification notification in response.Notifications) {
+					row = new TableRow ();
+					row.Cells.Add (Utils.CreateTableCell (notification.name));
+					if (notification.ircidentity_id.HasValue) {
+						row.Cells.Add (Utils.CreateTableCell (response.IrcIdentities.Find ((v) => v.id == notification.ircidentity_id.Value).name));
+						row.Cells.Add (Utils.CreateTableCell ("IRC"));
+					} else if (notification.emailidentity_id.HasValue) {
+						row.Cells.Add (Utils.CreateTableCell (response.EmailIdentities.Find ((v) => v.id == notification.emailidentity_id.Value).name));
+						row.Cells.Add (Utils.CreateTableCell ("Email"));
+					} else {
+						row.Cells.Add (Utils.CreateTableCell ("?"));
+						row.Cells.Add (Utils.CreateTableCell ("?"));
+					}
+					row.Cells.Add (Utils.CreateTableCell (cmbMode.Items [notification.mode].Text));
+					row.Cells.Add (Utils.CreateTableCell (cmbNotificationType.Items [notification.type].Text));
+					row.Cells.Add (Utils.CreateTableCell (Utils.CreateLinkButton ("remove_notification_" + notification.id.ToString (), "Remove", "RemoveNotification", notification.id.ToString (), OnLinkButtonCommand)));
+					tblNotifications.Rows.AddAt (tblNotifications.Rows.Count - 1, row);
+				}
+			}
 		}
 	}
 
@@ -89,19 +84,15 @@ public partial class Notifications : System.Web.UI.Page
 	{
 		WebServiceResponse response;
 
-		try {
-			switch (e.CommandName) {
-			case "RemoveNotification":
-				response = Master.WebService.RemoveNotification (Master.WebServiceLogin, int.Parse ((string) e.CommandArgument));
-				if (response.Exception != null) {
-					lblMessage.Text = response.Exception.Message;
-				} else {
-					Response.Redirect ("Notifications.aspx", false);
-				}
-				break;
+		switch (e.CommandName) {
+		case "RemoveNotification":
+			response = Master.WebService.RemoveNotification (Master.WebServiceLogin, int.Parse ((string) e.CommandArgument));
+			if (response.Exception != null) {
+				lblMessage.Text = response.Exception.Message;
+			} else {
+				Response.Redirect ("Notifications.aspx", false);
 			}
-		} catch (Exception ex) {
-			lblMessage.Text = ex.Message;
+			break;
 		}
 	}
 
@@ -109,29 +100,27 @@ public partial class Notifications : System.Web.UI.Page
 	{
 		WebServiceResponse response;
 
-		try {
-			DBNotification notification = new DBNotification ();
-			notification.mode = int.Parse (cmbMode.SelectedValue);
-			notification.name = txtName.Text;
-			notification.type = int.Parse (cmbNotificationType.SelectedValue);
-			if (cmbIdentity.SelectedItem.Text.StartsWith ("IRC: ")) {
-				notification.ircidentity_id = int.Parse (cmbIdentity.SelectedItem.Value);
-			} else if (cmbIdentity.SelectedItem.Text.StartsWith ("Email: ")) {
-				notification.emailidentity_id = int.Parse (cmbIdentity.SelectedItem.Value);
-			}
+		DBNotification notification = new DBNotification ();
+		notification.mode = int.Parse (cmbMode.SelectedValue);
+		notification.name = txtName.Text;
+		notification.type = int.Parse (cmbNotificationType.SelectedValue);
+		if (cmbIdentity.SelectedItem.Text.StartsWith ("IRC: ")) {
+			notification.ircidentity_id = int.Parse (cmbIdentity.SelectedItem.Value);
+		} else if (cmbIdentity.SelectedItem.Text.StartsWith ("Email: ")) {
+			notification.emailidentity_id = int.Parse (cmbIdentity.SelectedItem.Value);
+		}
 
-			if (string.IsNullOrEmpty (notification.name))
-				throw new Exception ("You need to specify the name of the notification");
+		if (string.IsNullOrEmpty (notification.name)) {
+			lblMessage.Text = "You need to specify the name of the notification";
+			return;
+		}
 
-			response = Master.WebService.EditNotification (Master.WebServiceLogin, notification);
+		response = Master.WebService.EditNotification (Master.WebServiceLogin, notification);
 
-			if (response.Exception != null) {
-				lblMessage.Text = response.Exception.Message;
-			} else {
-				Response.Redirect ("Notifications.aspx", false);
-			}
-		} catch (Exception ex) {
-			lblMessage.Text = ex.Message;
+		if (response.Exception != null) {
+			lblMessage.Text = response.Exception.Message;
+		} else {
+			Response.Redirect ("Notifications.aspx", false);
 		}
 	}
 }

--- a/MonkeyWrench.Web.UI/Releases.aspx.cs
+++ b/MonkeyWrench.Web.UI/Releases.aspx.cs
@@ -37,88 +37,84 @@ public partial class Releases : System.Web.UI.Page
 		GetReleasesResponse response;
 		int release_id;
 
-		try {
-			string action = Request ["action"];
+		string action = Request ["action"];
 
-			response = Master.WebService.GetReleases (Master.WebServiceLogin);
+		response = Master.WebService.GetReleases (Master.WebServiceLogin);
 
-			if (response.Exception != null) {
-				lblMessage.Text = response.Exception.Message;
-				return;
-			}
+		if (response.Exception != null) {
+			lblMessage.Text = response.Exception.Message;
+			return;
+		}
 
-			if (!string.IsNullOrEmpty (action)) {
-				switch (action) {
-				case "delete":
-					if (int.TryParse (Request ["release_id"], out release_id)) {
-						rsp = Master.WebService.DeleteRelease (Master.WebServiceLogin, release_id);
-						if (rsp.Exception != null) {
-							lblMessage.Text = rsp.Exception.Message;
-						} else {
-							Response.Redirect ("Releases.aspx", false);
-							return;
-						}
+		if (!string.IsNullOrEmpty (action)) {
+			switch (action) {
+			case "delete":
+				if (int.TryParse (Request ["release_id"], out release_id)) {
+					rsp = Master.WebService.DeleteRelease (Master.WebServiceLogin, release_id);
+					if (rsp.Exception != null) {
+						lblMessage.Text = rsp.Exception.Message;
 					} else {
-						lblMessage.Text = "Invalid release";
+						Response.Redirect ("Releases.aspx", false);
+						return;
 					}
+				} else {
+					lblMessage.Text = "Invalid release";
+				}
+				break;
+			case "download":
+				if (string.IsNullOrEmpty (Request ["release_id"]))
 					break;
-				case "download":
-					if (string.IsNullOrEmpty (Request ["release_id"]))
-						break;
 
-					if (int.TryParse (Request ["release_id"], out release_id)) {
-						foreach (DBRelease release in response.Releases) {
-							if (release.id != release_id)
-								continue;
-
-							Response.ContentType = "application/zip";
-							Response.AddHeader ("Content-Disposition", "attachment; filename=" + release.filename);
-							Response.TransmitFile (Path.Combine (Configuration.GetReleaseDirectory (), release.filename));
-							return;
-						}
-					} else if (Request ["release_id"] == "latest") {
-						Version latest = new Version ();
-						DBRelease release_latest = null;
-
-						foreach (DBRelease release in response.Releases) {
-							Version v = new Version (release.version);
-							if (v <= latest)
-								continue;
-							release_latest = release;
-						}
-
-						if (release_latest == null) {
-							Response.StatusCode = 404;
-							Response.Status = "Not found";
-							Response.StatusDescription = "No latest release exists";
-							return;
-						}
+				if (int.TryParse (Request ["release_id"], out release_id)) {
+					foreach (DBRelease release in response.Releases) {
+						if (release.id != release_id)
+							continue;
 
 						Response.ContentType = "application/zip";
-						Response.AddHeader ("Content-Disposition", "attachment; filename=" + release_latest.filename);
-						Response.TransmitFile (Path.Combine (Configuration.GetReleaseDirectory (), release_latest.filename));
+						Response.AddHeader ("Content-Disposition", "attachment; filename=" + release.filename);
+						Response.TransmitFile (Path.Combine (Configuration.GetReleaseDirectory (), release.filename));
 						return;
-					} else  {
-						lblMessage.Text = "Invalid release";
 					}
-					break;
-				}
-			}
+				} else if (Request ["release_id"] == "latest") {
+					Version latest = new Version ();
+					DBRelease release_latest = null;
 
-			foreach (DBRelease release in response.Releases) {
-				TableRow row = new TableRow ();
-				row.Cells.Add (Utils.CreateTableCell (release.version));
-				row.Cells.Add (Utils.CreateTableCell (release.revision));
-				row.Cells.Add (Utils.CreateTableCell (release.description));
-				row.Cells.Add (Utils.CreateTableCell (release.filename));
-				row.Cells.Add (Utils.CreateTableCell (
-					string.Format ("<a href='Releases.aspx?action=delete&amp;release_id={0}'>Delete</a>", release.id) + " " +
-					string.Format ("<a href='Releases.aspx?action=download&amp;release_id={0}'>Download</a>", release.id)
-					));
-				tblStatus.Rows.Add (row);
+					foreach (DBRelease release in response.Releases) {
+						Version v = new Version (release.version);
+						if (v <= latest)
+							continue;
+						release_latest = release;
+					}
+
+					if (release_latest == null) {
+						Response.StatusCode = 404;
+						Response.Status = "Not found";
+						Response.StatusDescription = "No latest release exists";
+						return;
+					}
+
+					Response.ContentType = "application/zip";
+					Response.AddHeader ("Content-Disposition", "attachment; filename=" + release_latest.filename);
+					Response.TransmitFile (Path.Combine (Configuration.GetReleaseDirectory (), release_latest.filename));
+					return;
+				} else  {
+					lblMessage.Text = "Invalid release";
+				}
+				break;
 			}
-		} catch (Exception ex) {
-			lblMessage.Text = ex.Message;
+		}
+
+		foreach (DBRelease release in response.Releases) {
+			TableRow row = new TableRow ();
+			row.Cells.Add (Utils.CreateTableCell (release.version));
+			row.Cells.Add (Utils.CreateTableCell (release.revision));
+			row.Cells.Add (Utils.CreateTableCell (release.description));
+			row.Cells.Add (Utils.CreateTableCell (release.filename));
+			row.Cells.Add (Utils.CreateTableCell (
+				string.Format ("<a href='Releases.aspx?action=delete&amp;release_id={0}'>Delete</a>", release.id) + " " +
+				string.Format ("<a href='Releases.aspx?action=download&amp;release_id={0}'>Download</a>", release.id)
+				));
+			tblStatus.Rows.Add (row);
 		}
 	}
 }

--- a/MonkeyWrench.Web.UI/ReportCommit.aspx.cs
+++ b/MonkeyWrench.Web.UI/ReportCommit.aspx.cs
@@ -27,45 +27,41 @@ public partial class ReportCommit : System.Web.UI.Page
 {
 	protected void Page_Load (object sender, EventArgs e)
 	{
-		try {
-			HttpPostedFile xml;
-			xml = Request.Files ["xml"];
+		HttpPostedFile xml;
+		xml = Request.Files ["xml"];
 
-			if (Request.UserHostAddress != "130.57.169.27" && Request.UserHostAddress != "130.57.21.45") {
-				Logger.Log ("ReportCommit.aspx: {0} tried to send a file, ignored.", Request.UserHostAddress);
+		if (Request.UserHostAddress != "130.57.169.27" && Request.UserHostAddress != "130.57.21.45") {
+			Logger.Log ("ReportCommit.aspx: {0} tried to send a file, ignored.", Request.UserHostAddress);
+			return;
+		}
+
+		if (xml != null) {
+			string outdir = Configuration.GetSchedulerCommitsDirectory ();
+			string outfile = Path.Combine (outdir, string.Format ("commit-{0}.xml", DateTime.Now.ToString ("yyyy-MM-dd-HH-mm-ss")));
+
+			if (xml.ContentLength > 1024 * 100) {
+				Logger.Log ("ReportCommit.aspx: {0} tried to send oversized file (> {1} bytes.", Request.UserHostAddress, 1024 * 100);
 				return;
 			}
 
-			if (xml != null) {
-				string outdir = Configuration.GetSchedulerCommitsDirectory ();
-				string outfile = Path.Combine (outdir, string.Format ("commit-{0}.xml", DateTime.Now.ToString ("yyyy-MM-dd-HH-mm-ss")));
+			if (!Directory.Exists (outdir))
+				Directory.CreateDirectory (outdir);
+			
+			Logger.Log ("ReportCommit.aspx: Got 'xml' from {2} with size {0} bytes, writing to '{1}'", xml.ContentLength, outfile, Request.UserHostAddress);
 
-				if (xml.ContentLength > 1024 * 100) {
-					Logger.Log ("ReportCommit.aspx: {0} tried to send oversized file (> {1} bytes.", Request.UserHostAddress, 1024 * 100);
-					return;
+			byte [] buffer = new byte [1024];
+			int read;
+			using (FileStream writer = new FileStream (outfile, FileMode.CreateNew, FileAccess.Write, FileShare.None, buffer.Length)) {
+				while (0 < (read = xml.InputStream.Read (buffer, 0, buffer.Length))) {
+					writer.Write (buffer, 0, read);
 				}
-
-				if (!Directory.Exists (outdir))
-					Directory.CreateDirectory (outdir);
-				
-				Logger.Log ("ReportCommit.aspx: Got 'xml' from {2} with size {0} bytes, writing to '{1}'", xml.ContentLength, outfile, Request.UserHostAddress);
-	
-				byte [] buffer = new byte [1024];
-				int read;
-				using (FileStream writer = new FileStream (outfile, FileMode.CreateNew, FileAccess.Write, FileShare.None, buffer.Length)) {
-					while (0 < (read = xml.InputStream.Read (buffer, 0, buffer.Length))) {
-						writer.Write (buffer, 0, read);
-					}
-				}
-
-				WebServices.ExecuteSchedulerAsync ();
-			} else {
-				Logger.Log ("ReportCommit.aspx: Didn't get a file called 'xml'");
 			}
 
-			Response.Write ("OK\n");
-		} catch (Exception ex) {
-			Logger.Log ("ReportCommit.aspx: Got exception: {0}", ex);
+			WebServices.ExecuteSchedulerAsync ();
+		} else {
+			Logger.Log ("ReportCommit.aspx: Didn't get a file called 'xml'");
 		}
+
+		Response.Write ("OK\n");
 	}
 }

--- a/MonkeyWrench.Web.UI/ReportGitHubCommit.aspx.cs
+++ b/MonkeyWrench.Web.UI/ReportGitHubCommit.aspx.cs
@@ -31,59 +31,58 @@ public partial class ReportGitHubCommit : System.Web.UI.Page
 {
 	protected void Page_Load (object sender, EventArgs e)
 	{
-		try {
-			string ip = Request.UserHostAddress;
-			bool ip_accepted = false;
-			string payload;
+		string ip = Request.UserHostAddress;
+		bool ip_accepted = false;
+		string payload;
 
-			Logger.Log ("ReportGitHubCommit.aspx: received post with {2} files from: {0} allowed ips: {1}", ip, Configuration.AllowedCommitReporterIPs, Request.Files.Count);
+		Logger.Log ("ReportGitHubCommit.aspx: received post with {2} files from: {0} allowed ips: {1}", ip, Configuration.AllowedCommitReporterIPs, Request.Files.Count);
 
-			foreach (HttpPostedFile f in Request.Files) {
-				Logger.Log ("ReportGitHubCommit.aspx: got file: {0}", f.FileName);
+		foreach (HttpPostedFile f in Request.Files) {
+			Logger.Log ("ReportGitHubCommit.aspx: got file: {0}", f.FileName);
+		}
+		foreach (string f in Request.Form.AllKeys) {
+			Logger.Log ("ReportGitHubCommit.aspx: {0}={1}", f, Request.Form [f]);
+		}
+
+		foreach (string allowed_ip in Configuration.AllowedCommitReporterIPs.Split ('.')) {
+			if (string.IsNullOrEmpty (ip))
+				continue;
+			if (Regex.IsMatch (ip, FileUtilities.GlobToRegExp (allowed_ip))) {
+				ip_accepted = true;
+				break;
 			}
-			foreach (string f in Request.Form.AllKeys) {
-				Logger.Log ("ReportGitHubCommit.aspx: {0}={1}", f, Request.Form [f]);
-			}
+		}
 
-			foreach (string allowed_ip in Configuration.AllowedCommitReporterIPs.Split ('.')) {
-				if (string.IsNullOrEmpty (ip))
-					continue;
-				if (Regex.IsMatch (ip, FileUtilities.GlobToRegExp (allowed_ip))) {
-					ip_accepted = true;
-					break;
-				}
-			}
+		if (!ip_accepted) {
+			Logger.Log ("ReportGitHubCommit.aspx: {0} tried to send a file, ignored. Allowed IPs: {1}", ip, Configuration.AllowedCommitReporterIPs);
+			return;
+		}
 
-			if (!ip_accepted) {
-				Logger.Log ("ReportGitHubCommit.aspx: {0} tried to send a file, ignored. Allowed IPs: {1}", ip, Configuration.AllowedCommitReporterIPs);
+		payload = Request ["payload"];
+
+		if (!string.IsNullOrEmpty (payload)) {
+			string outdir = Configuration.GetSchedulerCommitsDirectory ();
+			string outfile = Path.Combine (outdir, string.Format ("commit-{0}.xml", DateTime.Now.ToString ("yyyy-MM-dd-HH-mm-ss")));
+
+			if (payload.Length > 1024 * 100) {
+				Logger.Log ("ReportGitHubCommit.aspx: {0} tried to send oversized file (> {1} bytes.", Request.UserHostAddress, 1024 * 100);
 				return;
 			}
 
-			payload = Request ["payload"];
+			if (!Directory.Exists (outdir))
+				Directory.CreateDirectory (outdir);
 
-			if (!string.IsNullOrEmpty (payload)) {
-				string outdir = Configuration.GetSchedulerCommitsDirectory ();
-				string outfile = Path.Combine (outdir, string.Format ("commit-{0}.xml", DateTime.Now.ToString ("yyyy-MM-dd-HH-mm-ss")));
+			Logger.Log ("ReportGitHubCommit.aspx: Got 'payload' from {2} with size {0} bytes, writing to '{1}'", payload.Length, outfile, ip);
 
-				if (payload.Length > 1024 * 100) {
-					Logger.Log ("ReportGitHubCommit.aspx: {0} tried to send oversized file (> {1} bytes.", Request.UserHostAddress, 1024 * 100);
-					return;
-				}
+			JavaScriptSerializer json = new JavaScriptSerializer ();
+			GitHub.Payload pl = json.Deserialize<GitHub.Payload> (payload);
 
-				if (!Directory.Exists (outdir))
-					Directory.CreateDirectory (outdir);
-
-				Logger.Log ("ReportGitHubCommit.aspx: Got 'payload' from {2} with size {0} bytes, writing to '{1}'", payload.Length, outfile, ip);
-
-				JavaScriptSerializer json = new JavaScriptSerializer ();
-				GitHub.Payload pl = json.Deserialize<GitHub.Payload> (payload);
-
-				XmlWriterSettings settings = new XmlWriterSettings ();
-				settings.CloseOutput = true;
-				settings.Indent = true;
-				settings.IndentChars = "\t";
-				XmlWriter writer = XmlWriter.Create (outfile, settings);
-				/*
+			XmlWriterSettings settings = new XmlWriterSettings ();
+			settings.CloseOutput = true;
+			settings.Indent = true;
+			settings.IndentChars = "\t";
+			XmlWriter writer = XmlWriter.Create (outfile, settings);
+			/*
 # <monkeywrench version="1">
 #   <changeset sourcecountrol="svn|git" root="<repository root>" revision="<revision>">
 #     <directories>
@@ -92,41 +91,37 @@ public partial class ReportGitHubCommit : System.Web.UI.Page
 #     </directories>
 #   </changeset>
 # </monkeywrench>
-				 * */
-				writer.WriteStartElement ("monkeywrench");
-				writer.WriteAttributeString ("version", "1");
-				foreach (GitHub.Commit commit in pl.commits) {
-					writer.WriteStartElement ("changeset");
-					writer.WriteAttributeString ("sourcecontrol", "git");
-					writer.WriteAttributeString ("root", pl.repository.url);
-					writer.WriteAttributeString ("revision", commit.id);
-					writer.WriteStartElement ("directories");
-					HashSet<string> dirs = new HashSet<string> ();
-					foreach (string f in commit.added)
-						dirs.Add (Path.GetDirectoryName (f));
-					foreach (string f in commit.modified)
-						dirs.Add (Path.GetDirectoryName (f));
-					foreach (string f in commit.removed)
-						dirs.Add (Path.GetDirectoryName (f));
-					foreach (string dir in dirs) {
-						writer.WriteElementString ("directory", dir);
-					}
-					writer.WriteEndElement ();
-					writer.WriteEndElement ();
+			 * */
+			writer.WriteStartElement ("monkeywrench");
+			writer.WriteAttributeString ("version", "1");
+			foreach (GitHub.Commit commit in pl.commits) {
+				writer.WriteStartElement ("changeset");
+				writer.WriteAttributeString ("sourcecontrol", "git");
+				writer.WriteAttributeString ("root", pl.repository.url);
+				writer.WriteAttributeString ("revision", commit.id);
+				writer.WriteStartElement ("directories");
+				HashSet<string> dirs = new HashSet<string> ();
+				foreach (string f in commit.added)
+					dirs.Add (Path.GetDirectoryName (f));
+				foreach (string f in commit.modified)
+					dirs.Add (Path.GetDirectoryName (f));
+				foreach (string f in commit.removed)
+					dirs.Add (Path.GetDirectoryName (f));
+				foreach (string dir in dirs) {
+					writer.WriteElementString ("directory", dir);
 				}
 				writer.WriteEndElement ();
-				writer.Close ();
-
-			} else {
-				Logger.Log ("ReportCommit.aspx: Didn't get a file called 'payload'");
+				writer.WriteEndElement ();
 			}
+			writer.WriteEndElement ();
+			writer.Close ();
 
-			Response.Write ("OK\n");
-		} catch (Exception ex) {
-			Logger.Log ("ReportGitHubCommit.aspx: Got exception: {0}", ex);
-		} finally {
-			WebServices.ExecuteSchedulerAsync ();
+		} else {
+			Logger.Log ("ReportCommit.aspx: Didn't get a file called 'payload'");
 		}
+
+		Response.Write ("OK\n");
+		WebServices.ExecuteSchedulerAsync ();
 	}
 
 	private class GitHub

--- a/MonkeyWrench.Web.UI/SelectLanes.aspx.cs
+++ b/MonkeyWrench.Web.UI/SelectLanes.aspx.cs
@@ -30,66 +30,60 @@ public partial class SelectLanes : System.Web.UI.Page
 
 	protected void Page_Load (object sender, EventArgs e)
 	{
+		GetLanesResponse data;
 
-		try {
-			GetLanesResponse data;
+		string lanes_str = null;
+		string lane_ids_str = null;
 
-			string lanes_str = null;
-			string lane_ids_str = null;
+		string [] lanes = null;
+		int? [] lane_ids = null;
 
-			string [] lanes = null;
-			int? [] lane_ids = null;
+		HttpCookie cookie;
+		cookie = Request.Cookies ["index:lane"];
+		if (cookie != null) {
+			lanes_str = HttpUtility.UrlDecode (cookie.Value);
+		}
 
-			HttpCookie cookie;
-			cookie = Request.Cookies ["index:lane"];
-			if (cookie != null) {
-				lanes_str = HttpUtility.UrlDecode (cookie.Value);
+		cookie = Request.Cookies ["index:lane_id"];
+		if (cookie != null) {
+			lane_ids_str = HttpUtility.UrlDecode (cookie.Value);
+		}
+
+		if (!string.IsNullOrEmpty (lanes_str))
+			lanes = lanes_str.Split (';');
+		if (!string.IsNullOrEmpty (lane_ids_str)) {
+			string [] tmp = lane_ids_str.Split (';');
+			lane_ids = new int? [tmp.Length];
+			for (int i = 0; i < tmp.Length; i++) {
+				lane_ids [i] = Utils.TryParseInt32 (tmp [i]);
 			}
+		}
 
-			cookie = Request.Cookies ["index:lane_id"];
-			if (cookie != null) {
-				lane_ids_str = HttpUtility.UrlDecode (cookie.Value);
-			}
+		data = Master.WebService.GetLanes (Master.WebServiceLogin);
 
-			if (!string.IsNullOrEmpty (lanes_str))
-				lanes = lanes_str.Split (';');
-			if (!string.IsNullOrEmpty (lane_ids_str)) {
-				string [] tmp = lane_ids_str.Split (';');
-				lane_ids = new int? [tmp.Length];
-				for (int i = 0; i < tmp.Length; i++) {
-					lane_ids [i] = Utils.TryParseInt32 (tmp [i]);
-				}
-			}
+		foreach (DBLane lane in data.Lanes) {
+			if (lane.parent_lane_id.HasValue)
+				continue;
 
-			data = Master.WebService.GetLanes (Master.WebServiceLogin);
-
-			foreach (DBLane lane in data.Lanes) {
-				if (lane.parent_lane_id.HasValue)
-					continue;
-
-				CheckBox check = new CheckBox ();
-				check.ID = "chk" + lane.id.ToString ();
-				if (lane_ids != null) {
-					for (int i = 0; i < lane_ids.Length; i++) {
-						if (lane_ids [i] == lane.id) {
-							check.Checked = true;
-							break;
-						}
+			CheckBox check = new CheckBox ();
+			check.ID = "chk" + lane.id.ToString ();
+			if (lane_ids != null) {
+				for (int i = 0; i < lane_ids.Length; i++) {
+					if (lane_ids [i] == lane.id) {
+						check.Checked = true;
+						break;
 					}
 				}
-				if (!check.Checked && lanes != null) {
-					for (int i = 0; i < lanes.Length; i++) {
-						if (lanes [i] == lane.lane) {
-							check.Checked = true;
-							break;
-						}
+			}
+			if (!check.Checked && lanes != null) {
+				for (int i = 0; i < lanes.Length; i++) {
+					if (lanes [i] == lane.lane) {
+						check.Checked = true;
+						break;
 					}
 				}
-				tblLanes.Rows.AddAt (tblLanes.Rows.Count - 1, Utils.CreateTableRow (Utils.CreateTableCell (lane.lane), Utils.CreateTableCell (check)));
 			}
-
-		} catch (Exception ex) {
-			Response.Write (ex.ToString ().Replace ("\n", "<br/>"));
+			tblLanes.Rows.AddAt (tblLanes.Rows.Count - 1, Utils.CreateTableRow (Utils.CreateTableCell (lane.lane), Utils.CreateTableCell (check)));
 		}
 	}
 

--- a/MonkeyWrench.Web.UI/User.aspx.cs
+++ b/MonkeyWrench.Web.UI/User.aspx.cs
@@ -41,116 +41,107 @@ public partial class User : System.Web.UI.Page
 
 	protected void Page_Load (object sender, EventArgs e)
 	{
-		try {
-			int? id = null;
-			string username;
-			string action = Request ["action"];
+		int? id = null;
+		string username;
+		string action = Request ["action"];
 
-			if (!string.IsNullOrEmpty (Request ["id"])) {
-				int i;
-				if (int.TryParse (Request ["id"], out i)) {
-					id = i;
-				}
+		if (!string.IsNullOrEmpty (Request ["id"])) {
+			int i;
+			if (int.TryParse (Request ["id"], out i)) {
+				id = i;
 			}
+		}
 
-			username = Request ["username"];
+		username = Request ["username"];
 
-			if (!string.IsNullOrEmpty (action)) {
-				WebServiceResponse rsp;
-				string email = Request ["email"];
+		if (!string.IsNullOrEmpty (action)) {
+			WebServiceResponse rsp;
+			string email = Request ["email"];
 
-				switch (action) {
-				case "addemail":
-					if (!string.IsNullOrEmpty (email)) {
-						rsp = Master.WebService.AddUserEmail (Master.WebServiceLogin, id, username, email);
-						if (rsp.Exception != null) {
-							lblMessage.Text = rsp.Exception.Message;
-						} else {
-							Response.Redirect (GetSelfLink (), false);
-							return;
-						}
+			switch (action) {
+			case "addemail":
+				if (!string.IsNullOrEmpty (email)) {
+					rsp = Master.WebService.AddUserEmail (Master.WebServiceLogin, id, username, email);
+					if (rsp.Exception != null) {
+						lblMessage.Text = rsp.Exception.Message;
 					} else {
-						lblMessage.Text = "No email specified";
+						Response.Redirect (GetSelfLink (), false);
+						return;
 					}
-					break;
-				case "removeemail":
-					if (!string.IsNullOrEmpty (email)) {
-						rsp = Master.WebService.RemoveUserEmail (Master.WebServiceLogin, id, username, email);
-						if (rsp.Exception != null) {
-							lblMessage.Text = rsp.Exception.Message;
-						} else {
-							Response.Redirect (GetSelfLink (), false);
-							return;
-						}
-					} else {
-						lblMessage.Text = "No email specified";
-					}
-					break;
-				}
-			}
-
-			rowRoles.Visible = Authentication.IsInCookieRole (Request, Roles.Administrator);
-			if (!string.IsNullOrEmpty (username) || id.HasValue) {
-				response = Master.WebService.GetUser (Master.WebServiceLogin, id, username);
-
-				if (response.Exception == null) {
-					if (!IsPostBack) {
-						txtFullName.Text = response.User.fullname;
-						txtUserName.Text = response.User.login;
-						txtPassword.Text = response.User.password;
-						txtRoles.Text = response.User.roles;
-						txtIRCNicks.Text = response.User.irc_nicknames;
-
-						txtUserName.Attributes ["readonly"] = "readonly"; // asp.net sets readonly="ReadOnly", which fails w3 validation since casing isn't right
-					}
-
-					foreach (string email in response.User.Emails) {
-						tblUser.Rows.Add (Utils.CreateTableRow (Utils.CreateTableCell (email), Utils.CreateTableCell (string.Format ("<a href='{1}&action=removeemail&email={0}'>Remove</a>", HttpUtility.HtmlEncode (HttpUtility.UrlEncode (email)), GetSelfLink ()))));
-					}
-					TableCell cell = Utils.CreateTableCell (string.Format ("<a href=\"javascript:adduseremail ('{0}')\">Add email</a>", GetSelfLink ()));
-					cell.ColumnSpan = 2;
-					tblUser.Rows.Add (Utils.CreateTableRow (cell));
 				} else {
-					lblMessage.Text = response.Exception.Message;
+					lblMessage.Text = "No email specified";
 				}
-			} else {
-				cmdSave.Text = "Create new user";
+				break;
+			case "removeemail":
+				if (!string.IsNullOrEmpty (email)) {
+					rsp = Master.WebService.RemoveUserEmail (Master.WebServiceLogin, id, username, email);
+					if (rsp.Exception != null) {
+						lblMessage.Text = rsp.Exception.Message;
+					} else {
+						Response.Redirect (GetSelfLink (), false);
+						return;
+					}
+				} else {
+					lblMessage.Text = "No email specified";
+				}
+				break;
 			}
+		}
 
-		} catch (Exception ex) {
-			lblMessage.Text = ex.Message.Replace ("\n", "<br />");
+		rowRoles.Visible = Authentication.IsInCookieRole (Request, Roles.Administrator);
+		if (!string.IsNullOrEmpty (username) || id.HasValue) {
+			response = Master.WebService.GetUser (Master.WebServiceLogin, id, username);
+
+			if (response.Exception == null) {
+				if (!IsPostBack) {
+					txtFullName.Text = response.User.fullname;
+					txtUserName.Text = response.User.login;
+					txtPassword.Text = response.User.password;
+					txtRoles.Text = response.User.roles;
+					txtIRCNicks.Text = response.User.irc_nicknames;
+
+					txtUserName.Attributes ["readonly"] = "readonly"; // asp.net sets readonly="ReadOnly", which fails w3 validation since casing isn't right
+				}
+
+				foreach (string email in response.User.Emails) {
+					tblUser.Rows.Add (Utils.CreateTableRow (Utils.CreateTableCell (email), Utils.CreateTableCell (string.Format ("<a href='{1}&action=removeemail&email={0}'>Remove</a>", HttpUtility.HtmlEncode (HttpUtility.UrlEncode (email)), GetSelfLink ()))));
+				}
+				TableCell cell = Utils.CreateTableCell (string.Format ("<a href=\"javascript:adduseremail ('{0}')\">Add email</a>", GetSelfLink ()));
+				cell.ColumnSpan = 2;
+				tblUser.Rows.Add (Utils.CreateTableRow (cell));
+			} else {
+				lblMessage.Text = response.Exception.Message;
+			}
+		} else {
+			cmdSave.Text = "Create new user";
 		}
 	}
 
 	protected void cmdSave_OnClick (object sender, EventArgs e)
 	{
-		try {
-			WebServiceResponse rsp;
-			DBPerson user;
-			bool created = false;
+		WebServiceResponse rsp;
+		DBPerson user;
+		bool created = false;
 
-			if (response == null) {
-				user = new DBPerson ();
-				user.login = txtUserName.Text;
-				created = true;
-			} else {
-				user = response.User;
+		if (response == null) {
+			user = new DBPerson ();
+			user.login = txtUserName.Text;
+			created = true;
+		} else {
+			user = response.User;
+		}
+		user.fullname = txtFullName.Text;
+		user.password = txtPassword.Text;
+		user.roles = txtRoles.Text;
+		user.irc_nicknames = txtIRCNicks.Text;
+		rsp = Master.WebService.EditUser (Master.WebServiceLogin, user);
+		if (rsp.Exception != null) {
+			lblMessage.Text = rsp.Exception.Message;
+		} else {
+			if (!Authentication.IsLoggedIn (rsp) && created) {
+				Authentication.Login (user.login, user.password, Request, Response);
 			}
-			user.fullname = txtFullName.Text;
-			user.password = txtPassword.Text;
-			user.roles = txtRoles.Text;
-			user.irc_nicknames = txtIRCNicks.Text;
-			rsp = Master.WebService.EditUser (Master.WebServiceLogin, user);
-			if (rsp.Exception != null) {
-				lblMessage.Text = rsp.Exception.Message;
-			} else {
-				if (!Authentication.IsLoggedIn (rsp) && created) {
-					Authentication.Login (user.login, user.password, Request, Response);
-				}
-				Response.Redirect ("User.aspx?username=" + HttpUtility.UrlEncode (user.login), false);
-			}
-		} catch (Exception ex) {
-			lblMessage.Text = ex.ToString ().Replace ("\n", "<br />");
+			Response.Redirect ("User.aspx?username=" + HttpUtility.UrlEncode (user.login), false);
 		}
 	}
 }

--- a/MonkeyWrench.Web.UI/Users.aspx.cs
+++ b/MonkeyWrench.Web.UI/Users.aspx.cs
@@ -31,44 +31,40 @@ public partial class Users : System.Web.UI.Page
 
 	protected void Page_Load (object sender, EventArgs e)
 	{
-		try {
-			string action = Request ["action"];
-			int id;
+		string action = Request ["action"];
+		int id;
 
-			if (!string.IsNullOrEmpty (action)) {
-				switch (action) {
-				case "delete":
-					if (int.TryParse (Request ["id"], out id)) {
-						WebServiceResponse rsp = Master.WebService.DeleteUser (Master.WebServiceLogin, id);
-						if (rsp.Exception != null) {
-							lblMessage.Text = Utils.FormatException (response.Exception.Message);
-						} else {
-							Response.Redirect ("Users.aspx", false);
-							return;
-						}
+		if (!string.IsNullOrEmpty (action)) {
+			switch (action) {
+			case "delete":
+				if (int.TryParse (Request ["id"], out id)) {
+					WebServiceResponse rsp = Master.WebService.DeleteUser (Master.WebServiceLogin, id);
+					if (rsp.Exception != null) {
+						lblMessage.Text = Utils.FormatException (response.Exception.Message);
 					} else {
-						lblMessage.Text = "Invalid id";
+						Response.Redirect ("Users.aspx", false);
+						return;
 					}
-					break;
+				} else {
+					lblMessage.Text = "Invalid id";
 				}
+				break;
 			}
+		}
 
-			response = Master.WebService.GetUsers (Master.WebServiceLogin);
+		response = Master.WebService.GetUsers (Master.WebServiceLogin);
 
-			if (response.Exception != null) {
-				lblMessage.Text = Utils.FormatException (response.Exception.Message);
-			} else if (response.Users != null) {
-				foreach (DBPerson person in response.Users) {
-					tblUsers.Rows.Add (Utils.CreateTableRow (
-						string.Format ("<a href='User.aspx?username={0}'>{0}</a>", HttpUtility.HtmlEncode (person.login)),
-						HttpUtility.HtmlEncode (person.fullname),
-						HttpUtility.HtmlEncode (person.roles),
-						HttpUtility.HtmlEncode (person.password),
-						string.Format ("<a href='Users.aspx?id={0}&amp;action=delete'>Delete</a>", person.id)));
-				}
+		if (response.Exception != null) {
+			lblMessage.Text = Utils.FormatException (response.Exception.Message);
+		} else if (response.Users != null) {
+			foreach (DBPerson person in response.Users) {
+				tblUsers.Rows.Add (Utils.CreateTableRow (
+					string.Format ("<a href='User.aspx?username={0}'>{0}</a>", HttpUtility.HtmlEncode (person.login)),
+					HttpUtility.HtmlEncode (person.fullname),
+					HttpUtility.HtmlEncode (person.roles),
+					HttpUtility.HtmlEncode (person.password),
+					string.Format ("<a href='Users.aspx?id={0}&amp;action=delete'>Delete</a>", person.id)));
 			}
-		} catch (Exception ex) {
-			lblMessage.Text = Utils.FormatException (ex);
 		}
 	}
 }

--- a/MonkeyWrench.Web.UI/ViewHostHistory.aspx.cs
+++ b/MonkeyWrench.Web.UI/ViewHostHistory.aspx.cs
@@ -40,80 +40,76 @@ public partial class ViewHostHistory : System.Web.UI.Page
 		int revision_id = 0;
 		int masterhost_id = 0;
 
-		try {
-			if (!int.TryParse (Request ["host_id"], out host_id)) {
-				// ?
-				return;
-			}
-
-			int.TryParse (Request ["lane_id"], out lane_id);
-			int.TryParse (Request ["revision_id"], out revision_id);
-			int.TryParse (Request ["masterhost_id"], out masterhost_id);
-			action = Request ["action"];
-
-			if (!string.IsNullOrEmpty (action) && masterhost_id > 0 && lane_id > 0 && revision_id > 0) {
-				switch (action) {
-				case "clearrevision":
-					Master.WebService.ClearRevision (Master.WebServiceLogin, lane_id, masterhost_id, revision_id);
-					break;
-				case "deleterevision":
-					Master.WebService.RescheduleRevision (Master.WebServiceLogin, lane_id, masterhost_id, revision_id);
-					break;
-				case "abortrevision":
-					Master.WebService.AbortRevision (Master.WebServiceLogin, lane_id, masterhost_id, revision_id);
-					break;
-				}
-
-				Response.Redirect (string.Format ("ViewHostHistory.aspx?host_id={0}", host_id), false);
-				Page.Visible = false;
-				return;
-			}
-
-
-			if (!int.TryParse (Request.QueryString ["limit"], out limit))
-				limit = 25;
-			if (!int.TryParse (Request.QueryString ["offset"], out offset))
-				offset = 0;
-
-			response = Master.WebService.GetWorkHostHistory (Master.WebServiceLogin, Utils.TryParseInt32 (Request ["host_id"]), Request ["host"], limit, offset);
-
-			string hdr;
-			if (Authentication.IsInRole (response, MonkeyWrench.DataClasses.Logic.Roles.Administrator)) {
-				hdr = string.Format ("History for <a href='EditHost.aspx?host_id={1}'>{0}</a>", response.Host.host, response.Host.id);
-			} else {
-				hdr = string.Format ("History for {0}", response.Host.host);
-			}
-			hostheader.InnerHtml = "<h2>" + hdr + "</h2>";
-
-			StringBuilder table = new StringBuilder ();
-			table.AppendLine ("<table class='buildstatus'>");
-			table.AppendLine ("<tr><td>Lane</td><td>Host</td><td>Revision</td><td>State</td><td>StartTime</td><td>Completed</td><td>Duration</td><td>Commands</td></tr>");
-			for (int i = 0; i < response.RevisionWorks.Count; i++) {
-				DBRevisionWork rw = response.RevisionWorks [i];
-				string lane = response.Lanes [i];
-				string revision = response.Revisions [i];
-				string host = response.Hosts [i];
-				DateTime starttime = response.StartTime [i].ToLocalTime ();
-				int duration = response.Durations [i];
-				table.Append ("<tr>");
-				table.AppendFormat ("<td><a href='ViewTable.aspx?lane_id={1}&host_id={2}'>{0}</a></td>", lane, rw.lane_id, rw.host_id);
-				table.AppendFormat ("<td>{0}</td>", host);
-				table.AppendFormat ("<td><a href='ViewLane.aspx?lane_id={0}&host_id={1}&revision_id={2}'>{3}</a></td>", rw.lane_id, rw.host_id, rw.revision_id, revision);
-				table.AppendFormat ("<td class='{0}'>{1}</td>", rw.State.ToString ().ToLower (), rw.State.ToString ());
-				table.AppendFormat ("<td>{0}</td>", starttime.ToString ("yyyy/MM/dd HH:mm:ss UTC"));
-				table.AppendFormat ("<td>{0}</td>", rw.completed ? "Yes" : "No");
-				table.AppendFormat ("<td>{0}</td>", TimeSpan.FromSeconds (duration).ToString ());
-				table.AppendFormat ("<td>" +
-					 "<a href='ViewHostHistory.aspx?lane_id={0}&host_id={1}&revision_id={2}&masterhost_id={3}&action=clearrevision'>Reset work</a> " +
-					 "<a href='ViewHostHistory.aspx?lane_id={0}&host_id={1}&revision_id={2}&masterhost_id={3}&action=deleterevision'>Delete work</a> " +
-					 "<a href='ViewHostHistory.aspx?lane_id={0}&host_id={1}&revision_id={2}&masterhost_id={3}&action=abortrevision'>Abort work</a> " + 
-					 "</td>", rw.lane_id, rw.workhost_id, rw.revision_id, rw.host_id);
-				table.AppendLine ("</tr>");
-			}
-			table.AppendLine ("</table>");
-			hosthistory.InnerHtml = table.ToString ();
-		} catch (Exception ex) {
-			Response.Write (HttpUtility.HtmlEncode (ex.ToString ()).Replace ("\n", "<br/>"));
+		if (!int.TryParse (Request ["host_id"], out host_id)) {
+			// ?
+			return;
 		}
+
+		int.TryParse (Request ["lane_id"], out lane_id);
+		int.TryParse (Request ["revision_id"], out revision_id);
+		int.TryParse (Request ["masterhost_id"], out masterhost_id);
+		action = Request ["action"];
+
+		if (!string.IsNullOrEmpty (action) && masterhost_id > 0 && lane_id > 0 && revision_id > 0) {
+			switch (action) {
+			case "clearrevision":
+				Master.WebService.ClearRevision (Master.WebServiceLogin, lane_id, masterhost_id, revision_id);
+				break;
+			case "deleterevision":
+				Master.WebService.RescheduleRevision (Master.WebServiceLogin, lane_id, masterhost_id, revision_id);
+				break;
+			case "abortrevision":
+				Master.WebService.AbortRevision (Master.WebServiceLogin, lane_id, masterhost_id, revision_id);
+				break;
+			}
+
+			Response.Redirect (string.Format ("ViewHostHistory.aspx?host_id={0}", host_id), false);
+			Page.Visible = false;
+			return;
+		}
+
+
+		if (!int.TryParse (Request.QueryString ["limit"], out limit))
+			limit = 25;
+		if (!int.TryParse (Request.QueryString ["offset"], out offset))
+			offset = 0;
+
+		response = Master.WebService.GetWorkHostHistory (Master.WebServiceLogin, Utils.TryParseInt32 (Request ["host_id"]), Request ["host"], limit, offset);
+
+		string hdr;
+		if (Authentication.IsInRole (response, MonkeyWrench.DataClasses.Logic.Roles.Administrator)) {
+			hdr = string.Format ("History for <a href='EditHost.aspx?host_id={1}'>{0}</a>", response.Host.host, response.Host.id);
+		} else {
+			hdr = string.Format ("History for {0}", response.Host.host);
+		}
+		hostheader.InnerHtml = "<h2>" + hdr + "</h2>";
+
+		StringBuilder table = new StringBuilder ();
+		table.AppendLine ("<table class='buildstatus'>");
+		table.AppendLine ("<tr><td>Lane</td><td>Host</td><td>Revision</td><td>State</td><td>StartTime</td><td>Completed</td><td>Duration</td><td>Commands</td></tr>");
+		for (int i = 0; i < response.RevisionWorks.Count; i++) {
+			DBRevisionWork rw = response.RevisionWorks [i];
+			string lane = response.Lanes [i];
+			string revision = response.Revisions [i];
+			string host = response.Hosts [i];
+			DateTime starttime = response.StartTime [i].ToLocalTime ();
+			int duration = response.Durations [i];
+			table.Append ("<tr>");
+			table.AppendFormat ("<td><a href='ViewTable.aspx?lane_id={1}&host_id={2}'>{0}</a></td>", lane, rw.lane_id, rw.host_id);
+			table.AppendFormat ("<td>{0}</td>", host);
+			table.AppendFormat ("<td><a href='ViewLane.aspx?lane_id={0}&host_id={1}&revision_id={2}'>{3}</a></td>", rw.lane_id, rw.host_id, rw.revision_id, revision);
+			table.AppendFormat ("<td class='{0}'>{1}</td>", rw.State.ToString ().ToLower (), rw.State.ToString ());
+			table.AppendFormat ("<td>{0}</td>", starttime.ToString ("yyyy/MM/dd HH:mm:ss UTC"));
+			table.AppendFormat ("<td>{0}</td>", rw.completed ? "Yes" : "No");
+			table.AppendFormat ("<td>{0}</td>", TimeSpan.FromSeconds (duration).ToString ());
+			table.AppendFormat ("<td>" +
+				 "<a href='ViewHostHistory.aspx?lane_id={0}&host_id={1}&revision_id={2}&masterhost_id={3}&action=clearrevision'>Reset work</a> " +
+				 "<a href='ViewHostHistory.aspx?lane_id={0}&host_id={1}&revision_id={2}&masterhost_id={3}&action=deleterevision'>Delete work</a> " +
+				 "<a href='ViewHostHistory.aspx?lane_id={0}&host_id={1}&revision_id={2}&masterhost_id={3}&action=abortrevision'>Abort work</a> " + 
+				 "</td>", rw.lane_id, rw.workhost_id, rw.revision_id, rw.host_id);
+			table.AppendLine ("</tr>");
+		}
+		table.AppendLine ("</table>");
+		hosthistory.InnerHtml = table.ToString ();
 	}
 }

--- a/MonkeyWrench.Web.UI/ViewHtmlReportEmbedded.aspx.cs
+++ b/MonkeyWrench.Web.UI/ViewHtmlReportEmbedded.aspx.cs
@@ -31,29 +31,25 @@ public partial class ViewHtmlReportEmbedded : System.Web.UI.Page
 
 	protected void Page_Load (object sender, EventArgs e)
 	{
-		try {
-			GetViewLaneDataResponse response;
+		GetViewLaneDataResponse response;
 
-			response = Master.WebService.GetViewLaneData2 (Master.WebServiceLogin,
-				Utils.TryParseInt32 (Request ["lane_id"]), Request ["lane"],
-				Utils.TryParseInt32 (Request ["host_id"]), Request ["host"],
-				Utils.TryParseInt32 (Request ["revision_id"]), Request ["revision"], false);
+		response = Master.WebService.GetViewLaneData2 (Master.WebServiceLogin,
+			Utils.TryParseInt32 (Request ["lane_id"]), Request ["lane"],
+			Utils.TryParseInt32 (Request ["host_id"]), Request ["host"],
+			Utils.TryParseInt32 (Request ["revision_id"]), Request ["revision"], false);
 
-			DBHost host = response.Host;
-			DBLane lane = response.Lane;
-			DBRevision revision = response.Revision;
+		DBHost host = response.Host;
+		DBLane lane = response.Lane;
+		DBRevision revision = response.Revision;
 
-			if (lane == null || host == null || revision == null) {
-				Response.Redirect ("index.aspx", false);
-				return;
-			}
-
-			header.InnerHtml = ViewLane.GenerateHeader (response, lane, host, revision, "Html report for");
-			htmlreport.Attributes ["src"] = Request.Url.ToString ().Replace ("Embedded", "");
-			htmlreport.Attributes ["onload"] = "javascript: resizeToFillIFrame (document.getElementById ('" + htmlreport.ClientID + "'));";
-			ClientScript.RegisterStartupScript (GetType (), "resizeIFrame", "<script type='text/javascript'>resizeToFillIFrame (document.getElementById ('" + htmlreport.ClientID + "'));</script>");
-		} catch (Exception ex) {
-			Response.Write (ex.ToString ().Replace ("\n", "<br/>"));
+		if (lane == null || host == null || revision == null) {
+			Response.Redirect ("index.aspx", false);
+			return;
 		}
+
+		header.InnerHtml = ViewLane.GenerateHeader (response, lane, host, revision, "Html report for");
+		htmlreport.Attributes ["src"] = Request.Url.ToString ().Replace ("Embedded", "");
+		htmlreport.Attributes ["onload"] = "javascript: resizeToFillIFrame (document.getElementById ('" + htmlreport.ClientID + "'));";
+		ClientScript.RegisterStartupScript (GetType (), "resizeIFrame", "<script type='text/javascript'>resizeToFillIFrame (document.getElementById ('" + htmlreport.ClientID + "'));</script>");
 	}
 }

--- a/MonkeyWrench.Web.UI/ViewLane.aspx.cs
+++ b/MonkeyWrench.Web.UI/ViewLane.aspx.cs
@@ -39,80 +39,76 @@ public partial class ViewLane : System.Web.UI.Page
 	{
 		base.OnLoad (e);
 
-		try {
-			string action = null;
+		string action = null;
 
-			int id;
+		int id;
 
-			response = Master.WebService.GetViewLaneData2 (Master.WebServiceLogin,
-				Utils.TryParseInt32 (Request ["lane_id"]), Request ["lane"],
-				Utils.TryParseInt32 (Request ["host_id"]), Request ["host"],
-				Utils.TryParseInt32 (Request ["revision_id"]), Request ["revision"], false);
+		response = Master.WebService.GetViewLaneData2 (Master.WebServiceLogin,
+			Utils.TryParseInt32 (Request ["lane_id"]), Request ["lane"],
+			Utils.TryParseInt32 (Request ["host_id"]), Request ["host"],
+			Utils.TryParseInt32 (Request ["revision_id"]), Request ["revision"], false);
 
-			if (response.Exception != null) {
-				if (response.Exception.HttpCode == 403) {
-					Master.RequestLogin ();
-					return;
-				}
-				lblMessage.Text = response.Exception.Message;
+		if (response.Exception != null) {
+			if (response.Exception.HttpCode == 403) {
+				Master.RequestLogin ();
 				return;
 			}
-
-			if (Authentication.IsInRole (response, MonkeyWrench.DataClasses.Logic.Roles.Administrator))
-				action = Request ["action"];
-
-
-			DBHost host = response.Host;
-			DBLane lane = response.Lane;
-			DBRevision revision = response.Revision;
-
-			if (lane == null || host == null || revision == null) {
-				Response.Redirect ("index.aspx", false);
-				return;
-			}
-
-			if (!string.IsNullOrEmpty (action)) {
-				switch (action) {
-				case "clearrevision":
-					Master.WebService.ClearRevision (Master.WebServiceLogin, lane.id, host.id, revision.id);
-					break;
-				case "deleterevision":
-					Master.WebService.RescheduleRevision (Master.WebServiceLogin, lane.id, host.id, revision.id);
-					break;
-				case "ignorerevision":
-					Master.WebService.IgnoreRevision (Master.WebServiceLogin, lane.id, host.id, revision.id);
-					break;
-				case "abortrevision":
-					Master.WebService.AbortRevision (Master.WebServiceLogin, lane.id, host.id, revision.id);
-					break;
-				case "clearstep":
-					if (int.TryParse (Request ["work_id"], out id))
-						Master.WebService.ClearWork (Master.WebServiceLogin, id);
-					break;
-				case "abortstep":
-					if (int.TryParse (Request ["work_id"], out id))
-						Master.WebService.AbortWork (Master.WebServiceLogin, id);
-					break;
-				case "pausestep":
-					if (int.TryParse (Request ["work_id"], out id))
-						Master.WebService.PauseWork (Master.WebServiceLogin, id);
-					break;
-				case "resumestep":
-					if (int.TryParse (Request ["work_id"], out id))
-						Master.WebService.ResumeWork (Master.WebServiceLogin, id);
-					break;
-				}
-
-				Response.Redirect (string.Format ("ViewLane.aspx?lane_id={0}&host_id={1}&revision_id={2}", lane.id, host.id, revision.id), false);
-				Page.Visible = false;
-				return;
-			}
-
-			header.InnerHtml = GenerateHeader (response, lane, host, revision, "Build of");
-			buildtable.InnerHtml = GenerateLane (response);
-		} catch (Exception ex) {
-			Response.Write (ex.ToString ().Replace ("\n", "<br/>"));
+			lblMessage.Text = response.Exception.Message;
+			return;
 		}
+
+		if (Authentication.IsInRole (response, MonkeyWrench.DataClasses.Logic.Roles.Administrator))
+			action = Request ["action"];
+
+
+		DBHost host = response.Host;
+		DBLane lane = response.Lane;
+		DBRevision revision = response.Revision;
+
+		if (lane == null || host == null || revision == null) {
+			Response.Redirect ("index.aspx", false);
+			return;
+		}
+
+		if (!string.IsNullOrEmpty (action)) {
+			switch (action) {
+			case "clearrevision":
+				Master.WebService.ClearRevision (Master.WebServiceLogin, lane.id, host.id, revision.id);
+				break;
+			case "deleterevision":
+				Master.WebService.RescheduleRevision (Master.WebServiceLogin, lane.id, host.id, revision.id);
+				break;
+			case "ignorerevision":
+				Master.WebService.IgnoreRevision (Master.WebServiceLogin, lane.id, host.id, revision.id);
+				break;
+			case "abortrevision":
+				Master.WebService.AbortRevision (Master.WebServiceLogin, lane.id, host.id, revision.id);
+				break;
+			case "clearstep":
+				if (int.TryParse (Request ["work_id"], out id))
+					Master.WebService.ClearWork (Master.WebServiceLogin, id);
+				break;
+			case "abortstep":
+				if (int.TryParse (Request ["work_id"], out id))
+					Master.WebService.AbortWork (Master.WebServiceLogin, id);
+				break;
+			case "pausestep":
+				if (int.TryParse (Request ["work_id"], out id))
+					Master.WebService.PauseWork (Master.WebServiceLogin, id);
+				break;
+			case "resumestep":
+				if (int.TryParse (Request ["work_id"], out id))
+					Master.WebService.ResumeWork (Master.WebServiceLogin, id);
+				break;
+			}
+
+			Response.Redirect (string.Format ("ViewLane.aspx?lane_id={0}&host_id={1}&revision_id={2}", lane.id, host.id, revision.id), false);
+			Page.Visible = false;
+			return;
+		}
+
+		header.InnerHtml = GenerateHeader (response, lane, host, revision, "Build of");
+		buildtable.InnerHtml = GenerateLane (response);
 	}
 
 	public static string GenerateHeader (GetViewLaneDataResponse response, DBLane lane, DBHost host, DBRevision revision, string description)

--- a/MonkeyWrench.Web.UI/ViewWorkTable.aspx.cs
+++ b/MonkeyWrench.Web.UI/ViewWorkTable.aspx.cs
@@ -32,31 +32,27 @@ public partial class ViewWorkTable : System.Web.UI.Page
 	{
 		base.OnLoad (e);
 
-		try {
-			DBHost host;
-			DBLane lane;
-			DBCommand command = null;
-			GetViewWorkTableDataResponse response;
+		DBHost host;
+		DBLane lane;
+		DBCommand command = null;
+		GetViewWorkTableDataResponse response;
 
-			response = Master.WebService.GetViewWorkTableData (Master.WebServiceLogin,
-				Utils.TryParseInt32 (Request ["lane_id"]), Request ["lane"],
-				Utils.TryParseInt32 (Request ["host_id"]), Request ["host"],
-				Utils.TryParseInt32 (Request ["command_id"]), Request ["command"]);
+		response = Master.WebService.GetViewWorkTableData (Master.WebServiceLogin,
+			Utils.TryParseInt32 (Request ["lane_id"]), Request ["lane"],
+			Utils.TryParseInt32 (Request ["host_id"]), Request ["host"],
+			Utils.TryParseInt32 (Request ["command_id"]), Request ["command"]);
 
-			lane = response.Lane;
-			host = response.Host;
-			command = response.Command;
+		lane = response.Lane;
+		host = response.Host;
+		command = response.Command;
 
-			if (lane == null || host == null || command == null) {
-				Response.Redirect ("index.aspx", false);
-				return;
-			}
-
-			header.InnerHtml = GenerateHeader (response, lane, host, command);
-			buildtable.InnerHtml = GenerateLane (response, lane, host, command);
-		} catch (Exception ex) {
-			Response.Write (ex.ToString ().Replace ("\n", "<br/>"));
+		if (lane == null || host == null || command == null) {
+			Response.Redirect ("index.aspx", false);
+			return;
 		}
+
+		header.InnerHtml = GenerateHeader (response, lane, host, command);
+		buildtable.InnerHtml = GenerateLane (response, lane, host, command);
 	}
 	public string GenerateHeader (GetViewWorkTableDataResponse response, DBLane lane, DBHost host, DBCommand command)
 	{


### PR DESCRIPTION
The error handling in wrench primarily works by wrapping handler methods in `try { ... } catch(Exception ex} { ... }` blocks, and writing the error (and possibly the traceback) to the page.

This has multiple issues; the error handling code:

* is duplicated in every function,
* isn't standardized (some show just the exception message, some display both the message and traceback),
* displays the error to the user (tracebacks might contain sensitive information), and
* doesn't write the error to the log.

This patch removes most of the `try catch(Exception)` blocks in the web UI, and implements the error handling code in the `Global.Application_Error` method. The error handling code will log the error (with traceback) to wrench's logfile, then will display a generic "wrench has encountered an error" page (or, if localhost connected, the error plus traceback).

Note: Add `?w=1` to the URL of the GitHub diff view to ignore the indentation changes. Alternatively, use `git diff -w`.