### PR TITLE
Added UnauthorizedException and check for it in Master and Global.

### DIFF
--- a/MonkeyWrench.Web.UI/Global.asax.cs
+++ b/MonkeyWrench.Web.UI/Global.asax.cs
@@ -77,10 +77,6 @@ namespace MonkeyWrench.Web.UI
 					Response.Write (HttpUtility.HtmlEncode (ex.ToString ()));
 					Response.Write ("</pre>");
 				} else {
-					var httpex = ex as HttpUnhandledException;
-					if (httpex != null)
-						ex = httpex.InnerException;
-
 					Response.Write (String.Format (@"
 						<!DOCTYPE html>
 						<html>
@@ -93,7 +89,7 @@ namespace MonkeyWrench.Web.UI
 						<p>Error summary: <samp>{0}: {1}</samp></p>
 						</body>
 						</html>
-					", HttpUtility.HtmlEncode (ex.GetType ().Name), HttpUtility.HtmlEncode (ex.Message)));
+					", HttpUtility.HtmlEncode (realException.GetType ().Name), HttpUtility.HtmlEncode (realException.Message)));
 				}
 			}
 

--- a/MonkeyWrench.Web.UI/Global.asax.cs
+++ b/MonkeyWrench.Web.UI/Global.asax.cs
@@ -11,11 +11,9 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Web;
-using System.Web.Security;
-using System.Web.SessionState;
+
+using MonkeyWrench.WebServices;
 
 namespace MonkeyWrench.Web.UI
 {
@@ -43,34 +41,62 @@ namespace MonkeyWrench.Web.UI
 
 		protected void Application_Error (object sender, EventArgs e)
 		{
+			Response.Clear ();
 			Exception ex = Server.GetLastError ();
-			Logger.Log ("{0}: {1}", Request.Url.AbsoluteUri, ex);
 
-			Response.StatusCode = 500;
+			// Unwrap HttpUnhandledException
+			Exception realException;
+			if (ex is HttpUnhandledException)
+				realException = (ex as HttpUnhandledException).InnerException;
+			else
+				realException = ex;
 
-			if (Request.IsLocal) {
-				Response.Write ("<pre>");
-				Response.Write (HttpUtility.HtmlEncode (ex.ToString ()));
-				Response.Write ("</pre>");
-			} else {
-				var httpex = ex as HttpUnhandledException;
-				if (httpex != null)
-					ex = httpex.InnerException;
-
+			if (realException is UnauthorizedException) {
+				// User is not authorized to view this page.
+				Response.StatusCode = 403;
 				Response.Write (String.Format (@"
 					<!DOCTYPE html>
 					<html>
 					<head>
-						<title>500 - Internal Server Error</title>
+						<title>Unauthorized</title>
 					</head>
 					<body>
-					<h1>Wrench encountered an error.</h1>
-					<p>We're sorry about that. The error has been logged, and will hopefully be fixed soon!</p>
-					<p>Error summary: <samp>{0}: {1}</samp></p>
+					<h1>Unauthorized.</h1>
+					<p>{0}</p>
 					</body>
 					</html>
-				", HttpUtility.HtmlEncode (ex.GetType().Name), HttpUtility.HtmlEncode (ex.Message)));
+				", HttpUtility.HtmlEncode (realException.Message)));
+			} else {
+				// Unhandled error. Log it and display an error page. 
+				Logger.Log ("{0}: {1}", Request.Url.AbsoluteUri, ex);
+
+				Response.StatusCode = 500;
+
+				if (Request.IsLocal) {
+					Response.Write ("<pre>");
+					Response.Write (HttpUtility.HtmlEncode (ex.ToString ()));
+					Response.Write ("</pre>");
+				} else {
+					var httpex = ex as HttpUnhandledException;
+					if (httpex != null)
+						ex = httpex.InnerException;
+
+					Response.Write (String.Format (@"
+						<!DOCTYPE html>
+						<html>
+						<head>
+							<title>500 - Internal Server Error</title>
+						</head>
+						<body>
+						<h1>Wrench encountered an error.</h1>
+						<p>We're sorry about that. The error has been logged, and will hopefully be fixed soon!</p>
+						<p>Error summary: <samp>{0}: {1}</samp></p>
+						</body>
+						</html>
+					", HttpUtility.HtmlEncode (ex.GetType ().Name), HttpUtility.HtmlEncode (ex.Message)));
+				}
 			}
+
 			Server.ClearError ();
 		}
 

--- a/MonkeyWrench.Web.WebService/Authentication.cs
+++ b/MonkeyWrench.Web.WebService/Authentication.cs
@@ -25,6 +25,27 @@ using MonkeyWrench.DataClasses.Logic;
 
 namespace MonkeyWrench.WebServices
 {
+	/**
+	 * Thrown when a user does not have access to a resource.
+	 */
+	public class UnauthorizedException : Exception {
+		public UnauthorizedException ()
+		{
+		}
+
+		public UnauthorizedException (string message) : base (message)
+		{
+		}
+
+		public UnauthorizedException (System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base (info, context)
+		{
+		}
+
+		public UnauthorizedException (string message, Exception innerException) : base (message, innerException)
+		{
+		}
+	}
+
 	public class Authentication {
 		/// <summary>
 		/// Authenticates the request with the provided user/pass.
@@ -125,7 +146,7 @@ namespace MonkeyWrench.WebServices
 		private static void VerifyAnonymousAllowed()
 		{
 			if (!Configuration.AllowAnonymousAccess)
-				throw new HttpException(403, "Anonymous access is not permitted.");
+				throw new UnauthorizedException ("Anonymous access is not permitted.");
 		}
 
 		public static void VerifyUserInRole (HttpContext Context, DB db, WebServiceLogin login, string role, bool @readonly)
@@ -135,7 +156,7 @@ namespace MonkeyWrench.WebServices
 
 			if (!dummy.IsInRole (role)) {
 				Logger.Log (2, "The user '{0}' has the roles '{1}', and requested role is: {2}", login.User, dummy.UserRoles == null ? "<null>" : string.Join (",", dummy.UserRoles), role);
-				throw new HttpException (403, "You don't have the required permissions.");
+				throw new UnauthorizedException ("You don't have the required permissions.");
 			}
 		}
 
@@ -146,7 +167,7 @@ namespace MonkeyWrench.WebServices
 
 			if (!dummy.IsInRole (role)) {
 				Logger.Log (2, "The user '{0}' has the roles '{1}', and requested role is: {2}", login.User, dummy.UserRoles == null ? "<null>" : string.Join (",", dummy.UserRoles), role);
-				throw new HttpException (403, "You don't have the required permissions.");
+				throw new UnauthorizedException ("You don't have the required permissions.");
 			}
 		}
 


### PR DESCRIPTION
If `AllowAnonymousAccess` is set to false, then `Utils.LocalWebService.GetLeftTreeData` will throw an `HttpException` with the 403 error code. But `GetLeftTreeData` is called on the login page, so the login page will error out and effectively lock out everyone.

This patch changes the `Authentication` class to throw a new `UnauthorizedException` instead of a generic `HttpException`. It also modifies `Master.cs` to check for the exception when calling `GetLeftTreeData`, and to not display the sidebar data if caught.

This patch also checks for `UnauthorizedException` in the global `Application_Error` handler, and render a simple "Unauthorized" page if so. But since authorization is mostly checked in WebService functions, which still have their own per-function error handling, it's unlikely to be visible. It works with a test page that throws `UnauthorizedException` though.

Private Wrench already has a (not as good) hotfix in place.

@rolfbjarne @duncanmak 