### PR TITLE
Fixed a race condition when starting up notifiers.

### DIFF
--- a/MonkeyWrench.Web.WebService/Notifications/Notifications.cs
+++ b/MonkeyWrench.Web.WebService/Notifications/Notifications.cs
@@ -116,10 +116,10 @@ namespace MonkeyWrench.WebServices
 			}
 
 			if (notifier_thread == null) {
+				queued_notifications = new BlockingCollection<QueuedNotification> ();
 				notifier_thread = new Thread (NotificationProcessor);
 				notifier_thread.IsBackground = true;
 				notifier_thread.Start ();
-				queued_notifications = new BlockingCollection<QueuedNotification> ();
 			}
 		}
 


### PR DESCRIPTION
`queued_notifications` gets initialized after the thread has started, so the thread may attempt to poll a value from it before it gets initialized.

@rolfbjarne 