### PR TITLE
Change default DatabaseHost to 127.0.0.1 instead of localhost

### DIFF
--- a/MonkeyWrench/Configuration.cs
+++ b/MonkeyWrench/Configuration.cs
@@ -31,7 +31,7 @@ namespace MonkeyWrench
 		public static string WebSiteUrl;
 		public static bool ForceFullUpdate = true;
 		public static string WebServicePassword;
-		public static string DatabaseHost = "localhost";
+		public static string DatabaseHost = "127.0.0.1";
 		public static int DatabasePort;
 		public static string DatabaseName = "builder";
 		public static string DatabaseUser = "builder";


### PR DESCRIPTION
Apparently, `Dns.BeginGetHostAddresses` will do a DNS lookup for `"localhost"`, which is occasionally causing DNS timeout errors on private wrench. This changes the default database host to the IP `127.0.0.1`, which shouldn't need to perform a DNS lookup.