### PR TITLE
Added timing information to revision works.

### DIFF
--- a/MonkeyWrench.DataClasses/Database/DBRevisionWork.generated.cs
+++ b/MonkeyWrench.DataClasses/Database/DBRevisionWork.generated.cs
@@ -25,7 +25,10 @@ namespace MonkeyWrench.DataClasses
 		private int _state;
 		private DateTime _lock_expires;
 		private bool _completed;
-		private DateTime _endtime;
+		private DateTime? _createdtime;
+		private DateTime? _assignedtime;
+		private DateTime? _startedtime;
+		private DateTime? _endtime;
 
 		public int @lane_id { get { return _lane_id; } set { _lane_id = value; } }
 		public int @host_id { get { return _host_id; } set { _host_id = value; } }
@@ -34,7 +37,10 @@ namespace MonkeyWrench.DataClasses
 		public int @state { get { return _state; } set { _state = value; } }
 		public DateTime @lock_expires { get { return _lock_expires; } set { _lock_expires = value; } }
 		public bool @completed { get { return _completed; } set { _completed = value; } }
-		public DateTime @endtime { get { return _endtime; } set { _endtime = value; } }
+		public DateTime? @createdtime { get { return _createdtime; } set { _createdtime = value; } }
+		public DateTime? @assignedtime { get { return _assignedtime; } set { _assignedtime = value; } }
+		public DateTime? @startedtime { get { return _startedtime; } set { _startedtime = value; } }
+		public DateTime? @endtime { get { return _endtime; } set { _endtime = value; } }
 
 
 		public override string Table
@@ -47,7 +53,7 @@ namespace MonkeyWrench.DataClasses
 		{
 			get
 			{
-				return new string [] { "lane_id", "host_id", "workhost_id", "revision_id", "state", "lock_expires", "completed", "endtime" };
+				return new string [] { "lane_id", "host_id", "workhost_id", "revision_id", "state", "lock_expires", "completed", "createdtime", "assignedtime", "startedtime", "endtime" };
 			}
 		}
         

--- a/MonkeyWrench.DataClasses/Database/DBRevisionWorkView2.generated.cs
+++ b/MonkeyWrench.DataClasses/Database/DBRevisionWorkView2.generated.cs
@@ -23,7 +23,7 @@ namespace MonkeyWrench.DataClasses
 		private int _revision_id;
 		private int _state;
 		private bool _completed;
-		private DateTime _endtime;
+		private DateTime? _endtime;
 		private string _revision;
 		private DateTime _date;
 		private string _author;
@@ -33,7 +33,7 @@ namespace MonkeyWrench.DataClasses
 		public int @revision_id { get { return _revision_id; } set { _revision_id = value; } }
 		public int @state { get { return _state; } set { _state = value; } }
 		public bool @completed { get { return _completed; } set { _completed = value; } }
-		public DateTime @endtime { get { return _endtime; } set { _endtime = value; } }
+		public DateTime? @endtime { get { return _endtime; } set { _endtime = value; } }
 		public string @revision { get { return _revision; } set { _revision = value; } }
 		public DateTime @date { get { return _date; } set { _date = value; } }
 		public string @author { get { return _author; } set { _author = value; } }

--- a/MonkeyWrench.DataClasses/SqlToCSharp.cs
+++ b/MonkeyWrench.DataClasses/SqlToCSharp.cs
@@ -399,6 +399,7 @@ namespace MonkeyWrench.DataClasses
 						is_null = false;
 						break;
 					case "timestamp":
+					case "timestamptz":
 						mtype = "DateTime";
 						break;
 					case "boolean":

--- a/MonkeyWrench.Database/Extensions/DBRevisionWork_Extensions.cs
+++ b/MonkeyWrench.Database/Extensions/DBRevisionWork_Extensions.cs
@@ -323,7 +323,7 @@ WHERE
 		public static bool SetWorkHost (this DBRevisionWork rw, DB db, DBHost host)
 		{
 			object result;
-			string update_cmd = string.Format (@"UPDATE RevisionWork SET workhost_id = {0} WHERE id = {1} AND workhost_id IS NULL;", host.id, rw.id);
+			string update_cmd = string.Format (@"UPDATE RevisionWork SET workhost_id = {0}, assignedtime = NOW() WHERE id = {1} AND workhost_id IS NULL;", host.id, rw.id);
 
 			using (IDbCommand cmd = db.CreateCommand ()) {
 				cmd.CommandText = update_cmd;

--- a/MonkeyWrench.Web.UI/index.aspx.cs
+++ b/MonkeyWrench.Web.UI/index.aspx.cs
@@ -253,8 +253,8 @@ public partial class index : System.Web.UI.Page
 		bool is_working;
 		string str_date = string.Empty;
 
-		if (work.endtime.Year > 2000)
-			str_date = "<br/>" + TimeDiffToString (work.endtime, DateTime.UtcNow);
+		if (work.endtime != null && work.endtime.Value.Year > 2000)
+			str_date = "<br/>" + TimeDiffToString (work.endtime.Value, DateTime.UtcNow);
 
 		switch (state) {
 		case DBState.Executing:

--- a/MonkeyWrench.Web.WebService/WebNotification.cs
+++ b/MonkeyWrench.Web.WebService/WebNotification.cs
@@ -113,7 +113,7 @@ namespace MonkeyWrench.WebServices
 			return new Build {
 				Commit = revision.revision,
 				CommitId = revision.id,
-				Date = revisionWork.completed ? revisionWork.endtime : revision.date,
+				Date = revisionWork.endtime ?? revision.date,
 				Lane = lane.lane,
 				Project = parentLane.lane,
 				State = revisionWork.State,

--- a/scripts/database.sql
+++ b/scripts/database.sql
@@ -243,9 +243,24 @@ CREATE TABLE RevisionWork (
 	completed      boolean    NOT NULL DEFAULT FALSE, -- if this revision has completed its work
 	
 	createdtime  timestamptz NULL DEFAULT NOW(), -- Time that the RevisionWork was created
-	assignedtime timestamptz NULL,          -- Time that workhost_id was assigned
-	startedtime  timestamptz NULL,          -- Time that the first work was created, denormalized from `MIN(work.starttime) WHERE work.revisionwork_id = id`
-	endtime      timestamptz NULL,          -- Time that the RevisionWork was completed
+	assignedtime timestamptz NULL,               -- Time that workhost_id was assigned
+	startedtime  timestamptz NULL,               -- Time that the first work was created, denormalized from `MIN(work.starttime) WHERE work.revisionwork_id = id`
+	endtime      timestamptz NULL,               -- Time that the RevisionWork was completed
+	
+	-- alter table revisionwork add column endtime        timestamp  NOT NULL DEFAULT '2000-01-01 00:00:00+0';
+	
+	-- SET TIME ZONE 0; -- Set timezone to UTC
+	-- ALTER TABLE revisionwork ADD COLUMN createdtime timestamptz DEFAULT NULL; -- Fill existing rows with NULL...
+	-- ALTER TABLE revisionwork ALTER COLUMN createdtime SET DEFAULT NOW();      -- ...but new ones with NOW
+	-- ALTER TABLE revisionwork ADD COLUMN assignedtime timestamptz DEFAULT NULL;
+	-- ALTER TABLE revisionwork ADD COLUMN startedtime timestamptz DEFAULT NULL;
+	-- -- Change type and allow null for endtime, and convert '2000-01-01 00:00:00+0' to null.
+	-- ALTER TABLE revisionwork ADD COLUMN end_time_temp timestamptz DEFAULT NULL;
+	-- UPDATE revisionwork
+	-- 	SET end_time_temp = endtime
+	-- 	WHERE endtime != '2000-01-01 00:00:00+0'::timestamp;
+	-- ALTER TABLE revisionwork DROP COLUMN endtime;
+	-- ALTER TABLE revisionwork RENAME COLUMN end_time_temp TO endtime;
 	
 	UNIQUE (lane_id, host_id, revision_id)
 );

--- a/scripts/database.sql
+++ b/scripts/database.sql
@@ -241,8 +241,12 @@ CREATE TABLE RevisionWork (
 	
 	lock_expires   timestamp  NOT NULL DEFAULT '2000-01-01 00:00:00+0', -- the UTC time when this revisionwork's lock (if any) expires
 	completed      boolean    NOT NULL DEFAULT FALSE, -- if this revision has completed its work
-	endtime        timestamp  NOT NULL DEFAULT '2000-01-01 00:00:00+0', -- the UTC time this revisionwork finished working
-	-- alter table revisionwork add column endtime        timestamp  NOT NULL DEFAULT '2000-01-01 00:00:00+0';
+	
+	createdtime  timestamptz NULL DEFAULT NOW(), -- Time that the RevisionWork was created
+	assignedtime timestamptz NULL,          -- Time that workhost_id was assigned
+	startedtime  timestamptz NULL,          -- Time that the first work was created, denormalized from `MIN(work.starttime) WHERE work.revisionwork_id = id`
+	endtime      timestamptz NULL,          -- Time that the RevisionWork was completed
+	
 	UNIQUE (lane_id, host_id, revision_id)
 );
 CREATE INDEX RevisionWork_revision_id_idx ON RevisionWork (revision_id);


### PR DESCRIPTION
This commit adds 3 columns and edits 1 column in the `RevisionWork` table:

* `CreatedTime`, which is the time that the work is created.
* `AssignedTime`, which is the time that the work is assigned to a bot.
* `StartedTime`, which is the time that the first step of the work is started.
* `EndTime`, which is the time that the work is completed (modified so that NULL is used instead of some date in 2000 as a 'not completed' value).

We're going to use these timings to track slow lanes and find bottlenecks (and make pretty charts).

I've previously kept this data in a separate `revisionwork_info_log` table, which is populated using database triggers when the `RevisionWork` table is changed, but this required the database to join the two (fairly large) tables together, resulting in poor performance.

Here's the database migration script:

```sql
BEGIN;

SET TIME ZONE 0; -- Set timezone to UTC

ALTER TABLE revisionwork ADD COLUMN createdtime timestamptz DEFAULT NULL; -- Fill existing rows with NULL...
ALTER TABLE revisionwork ALTER COLUMN createdtime SET DEFAULT NOW();      -- ...but new ones with NOW()

ALTER TABLE revisionwork ADD COLUMN assignedtime timestamptz DEFAULT NULL;
ALTER TABLE revisionwork ADD COLUMN startedtime timestamptz DEFAULT NULL;

-- Change type and allow null for endtime, and convert '2000-01-01 00:00:00+0' to null.
ALTER TABLE revisionwork ADD COLUMN end_time_temp timestamptz DEFAULT NULL;
UPDATE revisionwork
	SET end_time_temp = endtime
	WHERE endtime != '2000-01-01 00:00:00+0'::timestamp;
ALTER TABLE revisionwork DROP COLUMN endtime;
ALTER TABLE revisionwork RENAME COLUMN end_time_temp TO endtime;

-- If revisionwork_info_log doesn't exist, create a fake one to make the next few queries work.
CREATE TABLE IF NOT EXISTS revisionwork_info_log (revisionwork_id INT, created_time timestamp,
assigned_time timestamp, completed_time timestamp);

-- Migrate info from the revisionwork_info_log
UPDATE revisionwork
SET createdtime = log.created_time, assignedtime = log.assigned_time
FROM revisionwork_info_log AS log
WHERE log.revisionwork_id = revisionwork.id;

-- Migrate start times from the work table
UPDATE revisionwork
SET startedtime = (SELECT MIN(starttime) FROM work WHERE work.revisionwork_id = revisionwork.id)
WHERE assignedtime IS NOT NULL;

-- Drop old times table.
DROP TABLE IF EXISTS revisionwork_info_log CASCADE;

COMMIT;
```