### PR TITLE
Adjusted log levels in scheduler

### DIFF
--- a/MonkeyWrench.Web.WebService/Scheduler/Scheduler.cs
+++ b/MonkeyWrench.Web.WebService/Scheduler/Scheduler.cs
@@ -282,10 +282,10 @@ namespace MonkeyWrench.Scheduler
 						}
 
 						if (hostlane == null) {
-							log.InfoFormat ("AddWork: Lane '{0}' is not configured for host '{1}', not adding any work.", lane.lane, host.host);
+							log.DebugFormat ("AddWork: Lane '{0}' is not configured for host '{1}', not adding any work.", lane.lane, host.host);
 							continue;
 						} else if (!hostlane.enabled) {
-							log.InfoFormat ("AddWork: Lane '{0}' is disabled for host '{1}', not adding any work.", lane.lane, host.host);
+							log.DebugFormat ("AddWork: Lane '{0}' is disabled for host '{1}', not adding any work.", lane.lane, host.host);
 							continue;
 						}
 


### PR DESCRIPTION
These two messages are printed a lot (`lanes**hosts` times) and aren't very informative. This demotes them to debug level.

@rolfbjarne 