### PR TITLE
Expanded Json.aspx?type=botinfo

### DIFF
--- a/MonkeyWrench.Database/DB.cs
+++ b/MonkeyWrench.Database/DB.cs
@@ -865,13 +865,14 @@ WHERE
 UPDATE 
 	Work SET state = DEFAULT, summary = DEFAULT, starttime = DEFAULT, endtime = DEFAULT, duration = DEFAULT, logfile = DEFAULT, host_id = DEFAULT
 WHERE
-	Work.revisionwork_id IN 
+	Work.revisionwork_id = 
 		(SELECT	RevisionWork.id 
 			FROM RevisionWork
 			WHERE RevisionWork.host_id = @host_id AND RevisionWork.lane_id = @lane_id AND RevisionWork.revision_id = @revision_id);
 
 UPDATE 
-	RevisionWork SET state = DEFAULT, lock_expires = DEFAULT, completed = DEFAULT, workhost_id = DEFAULT, endtime = DEFAULT
+	RevisionWork SET state = DEFAULT, lock_expires = DEFAULT, completed = DEFAULT, workhost_id = DEFAULT,
+	createdtime = DEFAULT, assignedtime = DEFAULT, startedtime = DEFAULT, endtime = DEFAULT
 WHERE 
 		lane_id = @lane_id
 	AND revision_id = @revision_id 

--- a/MonkeyWrench.Web.UI/Global.asax.cs
+++ b/MonkeyWrench.Web.UI/Global.asax.cs
@@ -44,6 +44,9 @@ namespace MonkeyWrench.Web.UI
 		protected void Application_Error (object sender, EventArgs e)
 		{
 			Response.Clear ();
+
+			Response.ContentType = "text/html";
+
 			Exception ex = Server.GetLastError ();
 			Server.ClearError ();
 


### PR DESCRIPTION
A coworker needed more info from the botinfo endpoint; this patch provides it.

It also fixes two bugs: one where the new time columns added to `RevisionWork` were not reset when resetting a `RevisionWork`, another with the error page using the target page's content-type.

@rolfbjarne @duncanmak