### PR TITLE
Trim start of line since MSBuild indents the output

### DIFF
--- a/MonkeyWrench.Builder/Builder.cs
+++ b/MonkeyWrench.Builder/Builder.cs
@@ -580,7 +580,8 @@ namespace MonkeyWrench.Builder
 					List<bool> hidden = new List<bool> ();
 
 					while (null != (l = reader.ReadLine ())) {
-						line = l;
+						line = l.TrimStart (' ');
+						
 						if (line.StartsWith ("@Moonbuilder:")) {
 							line = line.Substring ("@Moonbuilder:".Length);
 						} else if (line.StartsWith ("@MonkeyWrench:")) {


### PR DESCRIPTION
This allows the MSBuild-based scripts to also inject commands for Wrench.