### PR TITLE
Adding enabled field to botstatus JSON

### DIFF
--- a/MonkeyWrench.Web.UI/Json.aspx.cs
+++ b/MonkeyWrench.Web.UI/Json.aspx.cs
@@ -101,6 +101,7 @@ namespace MonkeyWrench.Web.UI
 					results.Add (new Dictionary<string, object> {
 						{ "id", host.id },
 						{ "host", host.host },
+						{ "enabled", host.enabled },
 						{ "last_seen", status != null ? status.report_date.ToString ("yyyy/MM/dd HH:mm:ss UTC") : "" },
 						{ "last_job", this.GetHostHistory (db, host.id)},
 					});


### PR DESCRIPTION
The json output should also have the hosts current state.