### PR TITLE
Adding list of tags to laneinfo JSON endpoint and restructure as an array.

### DIFF
--- a/MonkeyWrench.Database/DB.cs
+++ b/MonkeyWrench.Database/DB.cs
@@ -724,6 +724,29 @@ SELECT family.id FROM family ORDER BY depth ASC;";
 
 			return result;
 		}
+
+		/// <summary>
+		/// Returns lane that matches lane_id in the database
+		/// </summary>
+		/// <returns></returns>
+		public DBLane GetLane (int id)
+		{
+			using (IDbCommand cmd = CreateCommand ()) {
+				cmd.CommandText = "SELECT * FROM Lane WHERE id = @id ";
+				DB.CreateParameter (cmd, "id", id);
+				using (IDataReader reader = cmd.ExecuteReader ()) {
+					if (!reader.Read ())
+						return null;
+					if (reader.IsDBNull (0))
+						return null;
+
+					DBLane lane = new DBLane ();
+					lane.Load (reader);
+					return lane;
+				}
+			}
+		}
+
 		/// <summary>
 		/// Returns all the lanes for which there are revisions in the database
 		/// </summary>

--- a/MonkeyWrench.Web.WebService/WebServices.asmx.cs
+++ b/MonkeyWrench.Web.WebService/WebServices.asmx.cs
@@ -1595,6 +1595,15 @@ WHERE hidden = false AND Lane.enabled = TRUE";
 			}
 		}
 
+
+		public List<DBLaneTag> GetTagsForLane (WebServiceLogin login, int lane_id)
+		{
+			using (DB db = new DB ()) {
+				Authenticate (db, login, null, true);
+				return db.GetLane(lane_id).GetTags(db);
+			}
+		}
+
 		[WebMethod]
 		public void DeleteLane (WebServiceLogin login, int lane_id)
 		{


### PR DESCRIPTION
The lane info endpoint use to return a lanes object with key / values pairs where the key was the lane name. Lane tags have been added to the objects and now lanes is an array of lane objects.