### PR TITLE
Adding limit and offset to GetViewWorkTableData

### DIFF
--- a/MonkeyWrench.Web.UI/Json.aspx.cs
+++ b/MonkeyWrench.Web.UI/Json.aspx.cs
@@ -146,7 +146,8 @@ namespace MonkeyWrench.Web.UI
 				response = Utils.LocalWebService.GetViewWorkTableData (login,
 					Utils.TryParseInt32 (Request ["lane_id"]),    Request ["lane"],
 					Utils.TryParseInt32 (Request ["host_id"]),    Request ["host"],
-					Utils.TryParseInt32 (Request ["command_id"]), Request ["command"]);
+					Utils.TryParseInt32 (Request ["command_id"]), Request ["command"],
+				    offset, limit);
 
 				lane    = response.Lane;
 				host    = response.Host;

--- a/MonkeyWrench.Web.UI/ViewWorkTable.aspx.cs
+++ b/MonkeyWrench.Web.UI/ViewWorkTable.aspx.cs
@@ -40,7 +40,8 @@ public partial class ViewWorkTable : System.Web.UI.Page
 		response = Utils.LocalWebService.GetViewWorkTableData (Master.WebServiceLogin,
 			Utils.TryParseInt32 (Request ["lane_id"]), Request ["lane"],
 			Utils.TryParseInt32 (Request ["host_id"]), Request ["host"],
-			Utils.TryParseInt32 (Request ["command_id"]), Request ["command"]);
+			Utils.TryParseInt32 (Request ["command_id"]), Request ["command"],
+		    int.Parse(Request["offset"]), int.Parse(Request["limit"]));
 
 		lane = response.Lane;
 		host = response.Host;

--- a/MonkeyWrench.Web.WebService/WebServices.asmx.cs
+++ b/MonkeyWrench.Web.WebService/WebServices.asmx.cs
@@ -1913,9 +1913,13 @@ UPDATE Work SET state = @state WHERE Work.revisionwork_id = (SELECT RevisionWork
 		}
 
 		[WebMethod]
-		public GetViewWorkTableDataResponse GetViewWorkTableData (WebServiceLogin login, int? lane_id, string lane, int? host_id, string host, int? command_id, string command)
+		public GetViewWorkTableDataResponse GetViewWorkTableData (WebServiceLogin login, int? lane_id, string lane, int? host_id, string host, int? command_id, string command, int offset = 0, int limit = 250)
 		{
 			GetViewWorkTableDataResponse response = new GetViewWorkTableDataResponse ();
+
+			// Enforce the 250 limit
+			if (limit > 250)
+				limit = 250;
 
 			using (DB db = new DB ()) {
 				Authenticate (db, login, response);
@@ -1929,8 +1933,16 @@ UPDATE Work SET state = @state WHERE Work.revisionwork_id = (SELECT RevisionWork
 SELECT * 
 FROM WorkView2
 WHERE command_id = @command_id AND masterhost_id = @host_id AND lane_id = @lane_id
-ORDER BY date DESC LIMIT 250;
-";
+ORDER BY date DESC ";
+					
+					if (limit > 0)
+						cmd.CommandText += " LIMIT " + limit.ToString();
+					if (offset > 0)
+						cmd.CommandText += " OFFSET " + offset.ToString();
+					cmd.CommandText += ";";
+
+					Console.WriteLine(cmd.CommandText);
+
 					DB.CreateParameter (cmd, "command_id", response.Command.id);
 					DB.CreateParameter (cmd, "host_id", response.Host.id);
 					DB.CreateParameter (cmd, "lane_id", response.Lane.id);


### PR DESCRIPTION
The JSON endpoint uses this method to get step history. It would be nice to be able to step back more than 250 results. 
