### PR TITLE
Endpoint for getting the latest revision from any lane

### DIFF
--- a/MonkeyWrench.Web.UI/GetLatest.aspx
+++ b/MonkeyWrench.Web.UI/GetLatest.aspx
@@ -1,6 +1,1 @@
-﻿<%@ Page Language="C#" Inherits="MonkeyWrench.Web.UI.GetLatest" MasterPageFile="~/Master.master" %>
-<%@ MasterType VirtualPath="~/Master.master" %>
-<asp:Content ContentPlaceHolderID="content" ID="contentContent" runat="server">
-</asp:Content>
-
-
+﻿<%@ Page Language="C#" Inherits="MonkeyWrench.Web.UI.GetLatest" CodeBehind="GetLatest.aspx.cs" %>

--- a/MonkeyWrench.Web.UI/GetLatest.aspx.cs
+++ b/MonkeyWrench.Web.UI/GetLatest.aspx.cs
@@ -31,7 +31,7 @@ namespace MonkeyWrench.Web.UI
 			var laneName = Request.QueryString ["laneName"];
 			var baseURL = Request.QueryString ["url"] ?? "http://storage.bos.internalx.com";
 			var storagePref = Request.QueryString ["prefer"];
-			if (storagePref && storagePref.ToLower () == "azure") {
+			if (!string.IsNullOrEmpty(storagePref) && (storagePref.ToLower () == "azure")) {
 				baseURL = "https://bosstoragemirror.blob.core.windows.net";
 			}
 			var updateRequest = false;
@@ -41,18 +41,20 @@ namespace MonkeyWrench.Web.UI
 			var revision = getLatestRevision (webServiceLogin, laneName, step, 0, limit);
 
 			Action handleGetLatest = () => {
-//				var homePage = Page.ResolveUrl ("~/index.aspx");
-				var URL = revision != "" ? String.Format ("{0}/{1}/{2}/{3}/manifest", baseURL, laneName, revision.Substring (0, 2), revision) : null;
-//				Response.AppendHeader ("Access-Control-Allow-Origin", "*");
-//				Response.Redirect (URL);
-				if (URL) {
-					HttpWebResponse response = HttpWebRequest.Create (URL).GetResponse ();
-					if (response.StatusCode != 200) {
+				var URL = String.Format ("{0}/{1}/{2}/{3}/manifest", baseURL, laneName, revision.Substring (0, 2), revision);
+				Response.AppendHeader ("Access-Control-Allow-Origin", "*");
+				Response.AppendHeader ("Content-Type", "text/plain");
+
+				if (!string.IsNullOrEmpty(URL)) {
+					HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create (URL);
+					HttpWebResponse response = (HttpWebResponse)request.GetResponse ();
+					if (response.StatusCode != HttpStatusCode.OK) {
 						// Default to NAS
 						if (!URL.Contains ("storage.bos")) {
 							URL = String.Format ("{0}/{1}/{2}/{3}/manifest", "http://storage.bos.internalx.com", laneName, revision.Substring (0, 2), revision);
-							response = HttpWebRequest.Create (URL).GetResponse ();
-							if (response.StatusCode != 200) {
+							request = (HttpWebRequest)HttpWebRequest.Create (URL);
+							response = (HttpWebResponse)request.GetResponse ();
+							if (response.StatusCode != HttpStatusCode.OK) {
 								Response.Write ("Can't find manifest");
 								return;
 							}	
@@ -60,30 +62,23 @@ namespace MonkeyWrench.Web.UI
 						Response.Write ("Can't find manifest");
 						return; 
 					}
-					StreamReader reader = new StreamReader (response.GetResponseStream ());
-					string manifest = reader.ReadToEnd ();
-					reader.Close ();
-					Response.Write (manifest);
-				} else {
-					Response.Write ("No valid revisions");
+					using (var reader = new StreamReader (response.GetResponseStream ())) {
+						Response.Write (reader.ReadToEnd ());
+					}
 				}
 			};
 
-//			Action handleUpdate = () => {
-//				Response.Write("");
-//			};
-//
-//			if (updateRequest) {
-//				handleUpdate ();
-//			} else {
-//				handleGetLatest ();
-//			}
+			if (revision != "") {
+				handleGetLatest ();
+			} else {
+				Response.Write ("No Valid Revisions");
+			}
 		}
 
 		string getLatestRevision (WebServiceLogin login, string laneName, int step, int offset, int limit){
-			var lane = Utils.WebService.FindLane (login, null, laneName).lane;
-			var revisions = Utils.WebService.GetRevisions (login, null, laneName, step, offset).Revisions;
-			var revisionWorks = revisions.Select (r => Utils.WebService.GetRevisionWorkForLane (login, lane.id, r.id, -1).RevisionWork).ToList ();
+			var lane = Utils.LocalWebService.FindLane (login, null, laneName).lane;
+			var revisions = Utils.LocalWebService.GetRevisions (login, null, laneName, step, offset).Revisions;
+			var revisionWorks = revisions.Select (r => Utils.LocalWebService.GetRevisionWorkForLane (login, lane.id, r.id, -1).RevisionWork).ToList ();
 			var validRevisions = revisionWorks.Find (wl => validRevision (login, wl));
 
 			if (validRevisions != null) {
@@ -101,7 +96,7 @@ namespace MonkeyWrench.Web.UI
 
 		bool validRevision (WebServiceLogin login, List<DBRevisionWork> revisionWorkList) {
 			return revisionWorkList.Any (r => 
-				Utils.WebService.GetViewLaneData (login, r.lane_id, "", r.host_id, "", r.revision_id, "").WorkViews.Any (w => 
+				Utils.LocalWebService.GetViewLaneData (login, r.lane_id, "", r.host_id, "", r.revision_id, "").WorkViews.Any (w => 
 					w.command.Contains ("upload-to-storage") && w.State == DBState.Success));
 		}
 	}


### PR DESCRIPTION
Updated endpoint for getting the manifest from the latest revision with an uploaded build. There is a "prefer" parameter to specify if you want azure links or NAS links. If the azure link is not available, it defaults to NAS. Instead of redirecting, we just write the manifest directly to the page.

@duncanmak 