### PR TITLE
Set GitHub Button Visibility on Login Init

### DIFF
--- a/MonkeyWrench.Web.UI/Login.aspx.cs
+++ b/MonkeyWrench.Web.UI/Login.aspx.cs
@@ -66,6 +66,7 @@ public partial class Login : System.Web.UI.Page
 
 		cmdLoginOpenId.Visible = !string.IsNullOrEmpty (Configuration.OpenIdProvider);
 		cmdLoginOauth.Visible = !string.IsNullOrEmpty (Configuration.OauthClientId);
+		cmdLoginGitHubOauth.Visible = !string.IsNullOrEmpty (Configuration.GitHubOauthClientId);
 
 		if (!Configuration.AllowPasswordLogin) {
 			cmdLogin.Visible = Configuration.AllowPasswordLogin;


### PR DESCRIPTION
We need to set the button visibility for the GitHub Oauth Login Button, same as we do for OAuth/OpenID. Right now it's appearing in general, even if you didn't set up the tokens in the config file.