### PR TITLE
Add GetStatusInfo and amend GetJobInfo in Json.aspx

### DIFF
--- a/MonkeyWrench.Web.UI/Json.aspx.cs
+++ b/MonkeyWrench.Web.UI/Json.aspx.cs
@@ -76,8 +76,8 @@ namespace MonkeyWrench.Web.UI
 				case "botstatus":
 					Response.Write (GetBotStatusTimes ());
 					break;
-				case "jobinfo":
-					Response.Write (GetJobInfo ());
+				case "statusinfo":
+					Response.Write (GetStatusInfo ());
 				break;
 				default:
 					GetBotStatus ();
@@ -411,7 +411,7 @@ namespace MonkeyWrench.Web.UI
 			}
 		}
 
-		private string GetJobInfo () {
+		private string GetStatusInfo () {
 			var lane_id = Utils.TryParseInt32 (Request ["lane_id"]);
 			var host_id = Utils.TryParseInt32 (Request ["host_id"]);
 			var response = Utils.LocalWebService.GetViewLaneData2 (

--- a/MonkeyWrench.Web.UI/Json.aspx.cs
+++ b/MonkeyWrench.Web.UI/Json.aspx.cs
@@ -76,6 +76,9 @@ namespace MonkeyWrench.Web.UI
 				case "botstatus":
 					Response.Write (GetBotStatusTimes ());
 					break;
+				case "jobinfo":
+					Response.Write (GetJobInfo ());
+					break;
 				case "statusinfo":
 					Response.Write (GetStatusInfo ());
 				break;
@@ -409,6 +412,33 @@ namespace MonkeyWrench.Web.UI
 
 				return JsonConvert.SerializeObject (results, Formatting.Indented);
 			}
+		}
+
+		private string GetJobInfo () {
+			var lane_id = Utils.TryParseInt32 (Request ["lane_id"]);
+			var host_id = Utils.TryParseInt32 (Request ["host_id"]);
+			var response = Utils.LocalWebService.GetViewLaneData2 (
+				login,
+				lane_id, Request ["lane"],
+				host_id, Request ["host"],
+				Utils.TryParseInt32 (Request ["revision_id"]), Request ["revision"], false);
+			DBRevision dbr = response.Revision;
+			DBRevisionWork revisionwork = response.RevisionWork;
+			DBLane lane = response.Lane;
+			DBHost host = response.Host;
+			DBRevision revision = response.Revision;
+
+			var jobinfo = new {
+				revision = dbr.revision,
+				status = revisionwork.State,
+				author = dbr.author,
+				commit_date = dbr.date.ToLocalTime(),
+				commit_date_utc = dbr.date.ToString ("yyyy/MM/dd HH:mm:ss UTC"),
+				host = response.WorkHost.host,
+				host_id = response.WorkHost.id
+			};
+
+			return JsonConvert.SerializeObject (jobinfo, Formatting.Indented);
 		}
 
 		private string GetStatusInfo () {

--- a/MonkeyWrench.Web.UI/Json.aspx.cs
+++ b/MonkeyWrench.Web.UI/Json.aspx.cs
@@ -79,8 +79,8 @@ namespace MonkeyWrench.Web.UI
 				case "jobinfo":
 					Response.Write (GetJobInfo ());
 					break;
-				case "statusinfo":
-					Response.Write (GetStatusInfo ());
+				case "stepinfo":
+					Response.Write (GetStepInfo ());
 				break;
 				default:
 					GetBotStatus ();
@@ -441,7 +441,7 @@ namespace MonkeyWrench.Web.UI
 			return JsonConvert.SerializeObject (jobinfo, Formatting.Indented);
 		}
 
-		private string GetStatusInfo () {
+		private string GetStepInfo () {
 			var lane_id = Utils.TryParseInt32 (Request ["lane_id"]);
 			var host_id = Utils.TryParseInt32 (Request ["host_id"]);
 			var response = Utils.LocalWebService.GetViewLaneData2 (


### PR DESCRIPTION
GetJobInfo in the API was actually getting the status info from ViewLane.aspx, so we should amend it to be called GetStatusInfo instead, since that's more accurate. I also added GetJobInfo to actually get the top level info on the job. The same as you would see on the top of ViewLane.