### PR TITLE
Adjust GetManifest and GetMetadata Endpoints

### DIFF
--- a/MonkeyWrench.Web.UI/GetManifest.aspx.cs
+++ b/MonkeyWrench.Web.UI/GetManifest.aspx.cs
@@ -57,12 +57,9 @@ namespace MonkeyWrench.Web.UI
 				if (storagePref != "NAS") {
 					response = makeHttpRequest (getManifestUrl ("http://storage.bos.internalx.com", laneName, revision));
 					if (response.StatusCode != HttpStatusCode.OK) {
-						Response.Write ("Can't find manifest");
-						return;
+						throw new HttpException (404, "Can't find manifest");
 					}
 				}
-				Response.Write ("Can't find manifest");
-				return;
 			}
 			using (var reader = new StreamReader (response.GetResponseStream ())) {
 				Response.Write (reader.ReadToEnd ());

--- a/MonkeyWrench.Web.UI/GetManifest.aspx.cs
+++ b/MonkeyWrench.Web.UI/GetManifest.aspx.cs
@@ -34,38 +34,38 @@ namespace MonkeyWrench.Web.UI
 			if (!string.IsNullOrEmpty(storagePref) && (storagePref.ToLower () == "azure")) {
 				baseURL = "https://bosstoragemirror.blob.core.windows.net";
 			}
-			var updateRequest = false;
+
 			var step =  10;
 			var limit =  200;
 
 			revision = string.IsNullOrEmpty(revision) ? getLatestRevision (webServiceLogin, laneName, step, 0, limit) : revision;
 
-			Action handleGetLatest = () => {
-				Response.AppendHeader ("Access-Control-Allow-Origin", "*");
-				Response.AppendHeader ("Content-Type", "text/plain");
-
-				HttpWebResponse response = makeHttpRequest (getManifestUrl (baseURL, laneName, revision));
-				if (response.StatusCode != HttpStatusCode.OK) {
-					// Default to NAS
-					if (storagePref != "NAS") {
-						response = makeHttpRequest (getManifestUrl ("http://storage.bos.internalx.com", laneName, revision));
-						if (response.StatusCode != HttpStatusCode.OK) {
-							Response.Write ("Can't find manifest");
-							return;
-						}
-					}
-					Response.Write ("Can't find manifest");
-					return;
-				}
-				using (var reader = new StreamReader (response.GetResponseStream ())) {
-					Response.Write (reader.ReadToEnd ());
-				}
-			};
-
 			if (revision != "") {
-				handleGetLatest ();
+				handleGetManifest (baseURL, laneName, revision, storagePref);
 			} else {
 				Response.Write ("No Valid Revisions");
+			}
+		}
+
+		void handleGetManifest (string baseURL, string laneName, string revision, string storagePref) {
+			Response.AppendHeader ("Access-Control-Allow-Origin", "*");
+			Response.AppendHeader ("Content-Type", "text/plain");
+
+			HttpWebResponse response = makeHttpRequest (getManifestUrl (baseURL, laneName, revision));
+			if (response.StatusCode != HttpStatusCode.OK) {
+				// Default to NAS
+				if (storagePref != "NAS") {
+					response = makeHttpRequest (getManifestUrl ("http://storage.bos.internalx.com", laneName, revision));
+					if (response.StatusCode != HttpStatusCode.OK) {
+						Response.Write ("Can't find manifest");
+						return;
+					}
+				}
+				Response.Write ("Can't find manifest");
+				return;
+			}
+			using (var reader = new StreamReader (response.GetResponseStream ())) {
+				Response.Write (reader.ReadToEnd ());
 			}
 		}
 

--- a/MonkeyWrench.Web.UI/GetManifest.aspx.cs
+++ b/MonkeyWrench.Web.UI/GetManifest.aspx.cs
@@ -27,7 +27,7 @@ namespace MonkeyWrench.Web.UI
 			base.OnLoad (e); 
 			webServiceLogin = Authentication.CreateLogin (Request);
 
-			var laneName = Request.QueryString ["laneName"];
+			var lane = Request.QueryString ["lane"];
 			var revision = Request.QueryString ["revision"];
 			var baseURL = Request.QueryString ["url"] ?? "http://storage.bos.internalx.com";
 			var storagePref = Request.QueryString ["prefer"];
@@ -38,10 +38,10 @@ namespace MonkeyWrench.Web.UI
 			var step =  10;
 			var limit =  200;
 
-			revision = string.IsNullOrEmpty(revision) ? getLatestRevision (webServiceLogin, laneName, step, 0, limit) : revision;
+			revision = string.IsNullOrEmpty(revision) ? getLatestRevision (webServiceLogin, lane, step, 0, limit) : revision;
 
 			if (revision != "") {
-				handleGetManifest (baseURL, laneName, revision, storagePref);
+				handleGetManifest (baseURL, lane, revision, storagePref);
 			} else {
 				Response.Write ("No Valid Revisions");
 			}

--- a/MonkeyWrench.Web.UI/GetManifest.aspx.cs
+++ b/MonkeyWrench.Web.UI/GetManifest.aspx.cs
@@ -43,7 +43,7 @@ namespace MonkeyWrench.Web.UI
 			if (revision != "") {
 				handleGetManifest (baseURL, lane, revision, storagePref);
 			} else {
-				Response.Write ("No Valid Revisions");
+				throw new HttpException (404, "No Valid Revisions");
 			}
 		}
 

--- a/MonkeyWrench.Web.UI/GetMetadata.aspx.cs
+++ b/MonkeyWrench.Web.UI/GetMetadata.aspx.cs
@@ -34,38 +34,38 @@ namespace MonkeyWrench.Web.UI
 			if (!string.IsNullOrEmpty(storagePref) && (storagePref.ToLower () == "azure")) {
 				baseURL = "https://bosstoragemirror.blob.core.windows.net";
 			}
-			var updateRequest = false;
+
 			var step =  10;
 			var limit =  200;
 
 			revision = string.IsNullOrEmpty(revision) ? getLatestRevision (webServiceLogin, laneName, step, 0, limit) : revision;
 
-			Action handleGetLatest = () => {
-				Response.AppendHeader ("Access-Control-Allow-Origin", "*");
-				Response.AppendHeader ("Content-Type", "application/json");
-
-				HttpWebResponse response = makeHttpRequest (getManifestUrl (baseURL, laneName, revision));
-				if (response.StatusCode != HttpStatusCode.OK) {
-					// Default to NAS
-					if (storagePref != "NAS") {
-						response = makeHttpRequest (getManifestUrl ("http://storage.bos.internalx.com", laneName, revision));
-						if (response.StatusCode != HttpStatusCode.OK) {
-							Response.Write ("Can't find metadata");
-							return;
-						}
-					}
-					Response.Write ("Can't find metadata");
-					return;
-				}
-				using (var reader = new StreamReader (response.GetResponseStream ())) {
-					Response.Write (reader.ReadToEnd ());
-				}
-			};
-
 			if (revision != "") {
-				handleGetLatest ();
+				handleGetMetadata (baseURL, laneName, revision, storagePref);
 			} else {
 				Response.Write ("No Valid Revisions");
+			}
+		}
+
+		void handleGetMetadata (string baseURL, string laneName, string revision, string storagePref) {
+			Response.AppendHeader ("Access-Control-Allow-Origin", "*");
+			Response.AppendHeader ("Content-Type", "application/json");
+
+			HttpWebResponse response = makeHttpRequest (getManifestUrl (baseURL, laneName, revision));
+			if (response.StatusCode != HttpStatusCode.OK) {
+				// Default to NAS
+				if (storagePref != "NAS") {
+					response = makeHttpRequest (getManifestUrl ("http://storage.bos.internalx.com", laneName, revision));
+					if (response.StatusCode != HttpStatusCode.OK) {
+						Response.Write ("Can't find metadata");
+						return;
+					}
+				}
+				Response.Write ("Can't find metadata");
+				return;
+			}
+			using (var reader = new StreamReader (response.GetResponseStream ())) {
+				Response.Write (reader.ReadToEnd ());
 			}
 		}
 

--- a/MonkeyWrench.Web.UI/GetMetadata.aspx.cs
+++ b/MonkeyWrench.Web.UI/GetMetadata.aspx.cs
@@ -43,7 +43,7 @@ namespace MonkeyWrench.Web.UI
 			if (revision != "") {
 				handleGetMetadata (baseURL, lane, revision, storagePref);
 			} else {
-				Response.Write ("No Valid Revisions");
+				throw new HttpException (404, "No Valid Revisions");
 			}
 		}
 

--- a/MonkeyWrench.Web.UI/GetMetadata.aspx.cs
+++ b/MonkeyWrench.Web.UI/GetMetadata.aspx.cs
@@ -27,7 +27,7 @@ namespace MonkeyWrench.Web.UI
 			base.OnLoad (e); 
 			webServiceLogin = Authentication.CreateLogin (Request);
 
-			var laneName = Request.QueryString ["laneName"];
+			var lane = Request.QueryString ["lane"];
 			var revision = Request.QueryString ["revision"];
 			var baseURL = Request.QueryString ["url"] ?? "http://storage.bos.internalx.com";
 			var storagePref = Request.QueryString ["prefer"];
@@ -38,10 +38,10 @@ namespace MonkeyWrench.Web.UI
 			var step =  10;
 			var limit =  200;
 
-			revision = string.IsNullOrEmpty(revision) ? getLatestRevision (webServiceLogin, laneName, step, 0, limit) : revision;
+			revision = string.IsNullOrEmpty(revision) ? getLatestRevision (webServiceLogin, lane, step, 0, limit) : revision;
 
 			if (revision != "") {
-				handleGetMetadata (baseURL, laneName, revision, storagePref);
+				handleGetMetadata (baseURL, lane, revision, storagePref);
 			} else {
 				Response.Write ("No Valid Revisions");
 			}

--- a/MonkeyWrench.Web.UI/GetMetadata.aspx.cs
+++ b/MonkeyWrench.Web.UI/GetMetadata.aspx.cs
@@ -51,18 +51,16 @@ namespace MonkeyWrench.Web.UI
 			Response.AppendHeader ("Access-Control-Allow-Origin", "*");
 			Response.AppendHeader ("Content-Type", "application/json");
 
-			HttpWebResponse response = makeHttpRequest (getManifestUrl (baseURL, laneName, revision));
+			HttpWebResponse response = makeHttpRequest (getMetadataUrl (baseURL, laneName, revision));
 			if (response.StatusCode != HttpStatusCode.OK) {
 				// Default to NAS
 				if (storagePref != "NAS") {
-					response = makeHttpRequest (getManifestUrl ("http://storage.bos.internalx.com", laneName, revision));
+					response = makeHttpRequest (getMetadataUrl ("http://storage.bos.internalx.com", laneName, revision));
 					if (response.StatusCode != HttpStatusCode.OK) {
-						Response.Write ("Can't find metadata");
+						throw new HttpException (404, "Can't find metadata");
 						return;
 					}
 				}
-				Response.Write ("Can't find metadata");
-				return;
 			}
 			using (var reader = new StreamReader (response.GetResponseStream ())) {
 				Response.Write (reader.ReadToEnd ());
@@ -74,7 +72,7 @@ namespace MonkeyWrench.Web.UI
 			return (HttpWebResponse)request.GetResponse ();
 		}
 
-		string getManifestUrl (string host, string laneName, string revision) {
+		string getMetadataUrl (string host, string laneName, string revision) {
 			return String.Format ("{0}/{1}/{2}/{3}/metadata", host, laneName, revision.Substring (0, 2), revision);
 		}
 


### PR DESCRIPTION
Following comments from @duncanmak here https://github.com/mono/monkeywrench/pull/80#issuecomment-227778972

- Renamed `laneName` to `lane` for both endpoints.
- Returns a 404 page if it fails, instead of just rewriting the response.
- Removed `handleGetLatest` Action and turned it into a method.
- Changed names of methods and variables in GetMetadata to better reflect that it is, in fact, in GetMetadata.