### PR TITLE
Expose the Wrench login information as environment variables

### DIFF
--- a/MonkeyWrench.Builder/Builder.cs
+++ b/MonkeyWrench.Builder/Builder.cs
@@ -300,6 +300,9 @@ namespace MonkeyWrench.Builder
 							p.StartInfo.EnvironmentVariables ["C_INCLUDE_PATH"] = Configuration.CygwinizePath (Configuration.GetCIncludePath (info.lane.id, info.revision.revision));
 							p.StartInfo.EnvironmentVariables ["CPLUS_INCLUDE_PATH"] = Configuration.CygwinizePath (Configuration.GetCPlusIncludePath (info.lane.id, info.revision.revision));
 
+							p.StartInfo.EnvironmentVariables["WRENCH_USERNAME"] = Configuration.Host;
+							p.StartInfo.EnvironmentVariables["WRENCH_PASSWORD"] = Configuration.WebServicePassword;
+
 							// We need to remove all paths from environment variables that were
 							// set for this executable to work so that they don't mess with 
 							// whatever we're trying to execute


### PR DESCRIPTION
@rolfbjarne @drasticactions @joewstroman 

Hey Rolf,

In the past, we managed `storage.bos.xamarin.com/<lane>/latest/manifest` as part of the `upload-to-storage` step, to allow build jobs to query for the latest build of a lane. This is error prone because the updating happened on the build bot and there are known cases where it would do it incorrectly, due to race conditions.

A better approach is to host this endpoint on Wrench itself, since it has perfect knowledge of the latest build for any lane. In addition, now that we have 2 storage locations (NAS and Azure), it would be nice to unify access to either location at the same endpoint.

This work is already done, and it's in `GetManifest.aspx` and `GetMetadata.aspx`.

However, in order to access these new endpoints, we now need to authenticate.

To that end, this PR adds `$WRENCH_USERNAME` and `$WRENCH_PASSWORD` as environment variables.

That means, all existing call-sites that look like:

    curl http://storage.bos.xamarin.com/<lane>/latest/manifest

Can be rewritten as:

    curl http://wrench.internalx.com/GetManifest.aspx?lane=<lane>&User=$WRENCH_USERNAME&Password=$WRENCH_PASSWORD

@rolfbjarne, what do you think?
