### PR TITLE
Handle HTTP 404s for files in GetManifest and GetMetadata

### DIFF
--- a/MonkeyWrench.Web.UI/GetManifest.aspx.cs
+++ b/MonkeyWrench.Web.UI/GetManifest.aspx.cs
@@ -68,7 +68,16 @@ namespace MonkeyWrench.Web.UI
 
 		HttpWebResponse makeHttpRequest (string url) {
 			HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create (url);
-			return (HttpWebResponse)request.GetResponse ();
+			try {
+				// If we get an exception, we want to return the failed response back up the chain.
+				return (HttpWebResponse)request.GetResponse();
+			}
+			catch (WebException exception) {
+				var response = exception.Response as HttpWebResponse;
+				if (response == null)
+					throw;
+				return response;
+			}
 		}
 
 		string getManifestUrl (string host, string laneName, string revision) {

--- a/MonkeyWrench.Web.UI/GetMetadata.aspx.cs
+++ b/MonkeyWrench.Web.UI/GetMetadata.aspx.cs
@@ -69,7 +69,16 @@ namespace MonkeyWrench.Web.UI
 
 		HttpWebResponse makeHttpRequest (string url) {
 			HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create (url);
-			return (HttpWebResponse)request.GetResponse ();
+			try {
+				// If we get an exception, we want to return the failed response back up the chain.
+				return (HttpWebResponse)request.GetResponse();
+			}
+			catch (WebException exception) {
+				var response = exception.Response as HttpWebResponse;
+				if (response == null)
+					throw;
+				return response;
+			}
 		}
 
 		string getMetadataUrl (string host, string laneName, string revision) {


### PR DESCRIPTION
GetManifest and GetMetadata have logic to handle if the initial file requested does not exist. It _should_ fall back to NAS, or otherwise fail. However while it was expected as written that if it got a 404, it would return a failure response. It does not, it throws a `HttpWebException` of a 404. To get around this, I wrapped `makeHttpRequest` in a try catch. If it does get a WebException, it will return the failed response back. If there is some other exception, it will throw as normal.