### PR TITLE
Refactor GitHub login to make it simpler

### DIFF
--- a/MonkeyWrench.Web.UI/Login.aspx.cs
+++ b/MonkeyWrench.Web.UI/Login.aspx.cs
@@ -102,10 +102,9 @@ public partial class Login : System.Web.UI.Page
 			LoginResponse loginResponse = new LoginResponse();
 			using (DB db = new DB()) {
 				try {
-					DBLogin_Extensions.Login(db, loginResponse, string.Empty, 
+					DBLogin_Extensions.GitHubLogin(db, loginResponse,
 					                              Utilities.GetExternalIP(Request), 
 					                              gitHubOrgTeamList,
-					                              true, 
 					                              authResult.GetGitHubLogin());
 				} catch (Exception ex) {
 					loginResponse.Exception = new WebServiceException(ex);
@@ -134,8 +133,7 @@ public partial class Login : System.Web.UI.Page
 			using (DB db = new DB ()) {
 				try {
 					DBLogin_Extensions.Login (db, loginResponse, authResult.GetEmail (), 
-					                               Utilities.GetExternalIP (Request), 
-					                               null);
+					                               Utilities.GetExternalIP (Request));
 				} catch (Exception ex) {
 					loginResponse.Exception = new WebServiceException (ex);
 				}

--- a/MonkeyWrench.Web.WebService/WebServices.asmx.cs
+++ b/MonkeyWrench.Web.WebService/WebServices.asmx.cs
@@ -98,7 +98,7 @@ namespace MonkeyWrench.WebServices
 
 			using (DB db = new DB ()) {
 				VerifyUserInRole (db, login, Roles.Administrator);
-				DBLogin_Extensions.Login (db, response, email, ip4, null);
+				DBLogin_Extensions.Login (db, response, email, ip4);
 				return response;
 			}
 		}


### PR DESCRIPTION
The code for logging in with GitHub, while functional, was a bit hard to understand. So to make it easier and cleaner, I refactored it. The old login methods for OpenID/Google are back to how they were, while GitHub has its own method for logging in, with much simpler logic for handling it. It also has its own error message should the user not be able to log in.