### PR TITLE
Hide protected branches

### DIFF
--- a/MonkeyWrench.Web.UI/Login.aspx.cs
+++ b/MonkeyWrench.Web.UI/Login.aspx.cs
@@ -117,6 +117,8 @@ public partial class Login : System.Web.UI.Page
 				Authentication.SetCookies(Response, loginResponse);
 				Response.Redirect(txtReferrer.Value, false);
 			}
+
+			Session["github_token"] = accessToken;
 			return;
 		}
 

--- a/MonkeyWrench.Web.UI/ViewLane.aspx.cs
+++ b/MonkeyWrench.Web.UI/ViewLane.aspx.cs
@@ -50,10 +50,10 @@ public partial class ViewLane : System.Web.UI.Page
 
 	bool IsBranchProtected(DBLane lane)
 	{
+		if (!lane.repository.Contains("github")) return false;
+
 		var repo = ParseRepo(lane.repository);
 		var branch = ParseBranch(lane.max_revision);
-
-		if (!repo.Contains("github")) return false;
 
 		var key = repo + ":" + branch;
 		var token = Session["github_token"];


### PR DESCRIPTION
This uses the GitHub API to check if a lane is building a protected branch on GitHub.

If a branch is protected, or if the build is successful, we now hide the reset/abort/delete links.

This is to avoid accidentally reseting builds that have already gone into testing.
