### PR TITLE
Assign 1 revision per lane

### DIFF
--- a/MonkeyWrench.Web.WebService/WebServices.asmx.cs
+++ b/MonkeyWrench.Web.WebService/WebServices.asmx.cs
@@ -3069,7 +3069,7 @@ LIMIT 1;
 				}
 
 				foreach (DBHostLane hl in hostlanes) {
-					int counter = 10;
+					int counter = 1;
 					DBRevisionWork revisionwork;
 					DBLane lane = null;
 					DBHost masterhost = null;


### PR DESCRIPTION
We'll need this in conjunction to the `OneRevisionAtATime` queue management to enforce that a bot only picks up one commit when it checks into wrench