### PR TITLE
Fix extra whitespace in AssemblyVersion

### DIFF
--- a/MonkeyWrench/Makefile
+++ b/MonkeyWrench/Makefile
@@ -3,5 +3,5 @@ generate-assembly-info:
 	@echo "Updating AssemblyInfo"
 	@cp AssemblyInfo.cs.in AssemblyInfo.tmp
 	@sed -e "s/.*AssemblyDescription.*/[assembly: AssemblyDescription (@\"MonkeyWrench (branch: `git branch | grep "^[*] " | sed 's/^[*] //'` commit #`git log --pretty=format:''|wc -l` sha: `git log --pretty=format:'%h' -1` date: `git log --pretty=format:'%ci' -1`) subject: `git log --pretty=format:'%s' -1 | sed 's_\\"_\\"\\"_g' | sed 's_/__g'`)\")]/" \
-	     -e "s/.*AssemblyVersion.*/[assembly: AssemblyVersion (\"1.0.0.`git log --pretty=format:''|wc -l`\")]/" AssemblyInfo.cs.in > AssemblyInfo.tmp
+		 -e "s/.*AssemblyVersion.*/[assembly: AssemblyVersion (\"1.0.0.`git log --pretty=format:''|wc -l|tr -d ' '`\")]/" AssemblyInfo.cs.in > AssemblyInfo.tmp
 	@rsync --checksum AssemblyInfo.tmp AssemblyInfo.cs


### PR DESCRIPTION
When generating the AssemblyInfo.cs file we end up with extra whitespace:

`[assembly: AssemblyVersion ("1.0.0.     787")]`

This compiled fine in previous versions of mono. But in 4.9.0 this is
enforced as invalid.

```
AssemblyInfo.cs(27,29): error CS7034: The specified version string does
not conform to the required format - major[.minor[.build[.revision]]]
```

This removes the extra whitespace and makes the version number valid.