### PR TITLE
Builder: Trim all whitespace at start, not only spaces

### DIFF
--- a/MonkeyWrench.Builder/Builder.cs
+++ b/MonkeyWrench.Builder/Builder.cs
@@ -587,7 +587,7 @@ namespace MonkeyWrench.Builder
 					List<bool> hidden = new List<bool> ();
 
 					while (null != (l = reader.ReadLine ())) {
-						line = l.TrimStart (' ');
+						line = l.TrimStart ();
 						
 						if (line.StartsWith ("@Moonbuilder:")) {
 							line = line.Substring ("@Moonbuilder:".Length);


### PR DESCRIPTION
There's more to whitespace than just spaces, so don't specify just whitespace
to be trimmed from the start of a line. This should allow things like MSBuild/xbuild 
outputting tab-indented `@MonkeyWrench` commands to work correctly.