### PR TITLE
Don't reset successful release builds

### DIFF
--- a/MonkeyWrench.Web.UI/ViewLane.aspx.cs
+++ b/MonkeyWrench.Web.UI/ViewLane.aspx.cs
@@ -256,7 +256,7 @@ public partial class ViewLane : System.Web.UI.Page
 			} else {
 				if (response.RevisionWork.State == DBState.NotDone)
 					header.AppendFormat (" - <a href='ViewLane.aspx?lane_id={0}&amp;host_id={2}&amp;revision_id={1}&amp;action=ignorerevision'>don't build</a>", lane.id, dbr.id, host.id);
-				if (response.RevisionWork.State != DBState.NoWorkYet) {
+				if (response.RevisionWork.State == DBState.Failed || (response.RevisionWork.State != DBState.NoWorkYet && lane.priority != 2)) {
 					GenerateActionLink(header, lane, host, dbr, "clearrevision", "clear", "reset work", hidden);
 					GenerateActionLink(header, lane, host, dbr, "deleterevision", "delete", "delete work", hidden);
 				}


### PR DESCRIPTION
One of the ways we get into trouble with the "reset work" button is that it creates a new build that hashes to a different value. This can cause mishaps with QA and the releasing process, as well as with XamarinVS, which expects to download certain subcomponents at a certain hash.