### PR TITLE
Customized message instead of reset button

### DIFF
--- a/MonkeyWrench.DataClasses/Database/DBLane.generated.cs
+++ b/MonkeyWrench.DataClasses/Database/DBLane.generated.cs
@@ -30,6 +30,7 @@ namespace MonkeyWrench.DataClasses
 		private DateTime? _changed_date;
 		private string _additional_roles;
 		private int _priority;
+		private bool _is_protected;
 
 		public string @lane { get { return _lane; } set { _lane = value; } }
 		public string @source_control { get { return _source_control; } set { _source_control = value; } }
@@ -43,6 +44,7 @@ namespace MonkeyWrench.DataClasses
 		public DateTime? @changed_date { get { return _changed_date; } set { _changed_date = value; } }
 		public string @additional_roles { get { return _additional_roles; } set { _additional_roles = value; } }
 		public int @priority { get { return _priority; } set { _priority = value; } }
+		public bool @is_protected { get { return _is_protected; } set { _is_protected = value; } }
 
 
 		public override string Table
@@ -55,7 +57,7 @@ namespace MonkeyWrench.DataClasses
 		{
 			get
 			{
-				return new string [] { "lane", "source_control", "repository", "min_revision", "max_revision", "parent_lane_id", "commit_filter", "traverse_merge", "enabled", "changed_date", "additional_roles", "priority" };
+				return new string [] { "lane", "source_control", "repository", "min_revision", "max_revision", "parent_lane_id", "commit_filter", "traverse_merge", "enabled", "changed_date", "additional_roles", "priority", "is_protected" };
 			}
 		}
         

--- a/MonkeyWrench.DataClasses/Database/DBRevisionWork.generated.cs
+++ b/MonkeyWrench.DataClasses/Database/DBRevisionWork.generated.cs
@@ -30,6 +30,7 @@ namespace MonkeyWrench.DataClasses
 		private DateTime? _startedtime;
 		private DateTime? _endtime;
 		private int _priority;
+		private bool _is_protected;
 
 		public int @lane_id { get { return _lane_id; } set { _lane_id = value; } }
 		public int @host_id { get { return _host_id; } set { _host_id = value; } }
@@ -43,6 +44,7 @@ namespace MonkeyWrench.DataClasses
 		public DateTime? @startedtime { get { return _startedtime; } set { _startedtime = value; } }
 		public DateTime? @endtime { get { return _endtime; } set { _endtime = value; } }
 		public int @priority { get { return _priority; } set { _priority = value; } }
+		public bool @is_protected { get { return _is_protected; } set { _is_protected = value; } }
 
 
 		public override string Table
@@ -55,7 +57,7 @@ namespace MonkeyWrench.DataClasses
 		{
 			get
 			{
-				return new string [] { "lane_id", "host_id", "workhost_id", "revision_id", "state", "lock_expires", "completed", "createdtime", "assignedtime", "startedtime", "endtime", "priority" };
+				return new string [] { "lane_id", "host_id", "workhost_id", "revision_id", "state", "lock_expires", "completed", "createdtime", "assignedtime", "startedtime", "endtime", "priority", "is_protected" };
 			}
 		}
         

--- a/MonkeyWrench.Web.UI/EditLane.aspx
+++ b/MonkeyWrench.Web.UI/EditLane.aspx
@@ -97,6 +97,13 @@
                 <asp:TableCell>If a lane is enabled. If not enabled nothing will be done for it and it won't show up on the front page.</asp:TableCell>
             </asp:TableRow>
             <asp:TableRow>
+                <asp:TableCell>Protected:</asp:TableCell>
+                <asp:TableCell>
+                    <asp:CheckBox ID="chkProtected" runat="server" Width="600px"></asp:CheckBox>
+                </asp:TableCell>
+                <asp:TableCell>Builds that finish from protected lanes cannot be reset.</asp:TableCell>
+            </asp:TableRow>
+            <asp:TableRow>
                 <asp:TableCell>
                 </asp:TableCell>
                 <asp:TableCell>

--- a/MonkeyWrench.Web.UI/EditLane.aspx.cs
+++ b/MonkeyWrench.Web.UI/EditLane.aspx.cs
@@ -116,6 +116,7 @@ public partial class EditLane : System.Web.UI.Page
 			}
 			chkTraverseMerges.Checked = lane.traverse_merge;
 			chkEnabled.Checked = lane.enabled;
+			chkProtected.Checked = lane.is_protected;
 		}
 
 		if (!string.IsNullOrEmpty (action)) {
@@ -704,6 +705,7 @@ public partial class EditLane : System.Web.UI.Page
 		lane.enabled = chkEnabled.Checked;
 		lane.additional_roles = txtRoles.Text;
 		lane.priority = Int32.Parse (lstPriority.SelectedItem.Value);
+		lane.is_protected = chkProtected.Checked;
 
 		Utils.LocalWebService.EditLaneWithTags (Master.WebServiceLogin, lane, !string.IsNullOrEmpty (txtTags.Text) ? txtTags.Text.Split (',') : null);
 		RedirectToSelf ();

--- a/MonkeyWrench.Web.UI/EditLane.aspx.designer.cs
+++ b/MonkeyWrench.Web.UI/EditLane.aspx.designer.cs
@@ -43,6 +43,8 @@ public partial class EditLane {
 	protected System.Web.UI.WebControls.CheckBox chkTraverseMerges;
 	
 	protected System.Web.UI.WebControls.CheckBox chkEnabled;
+
+	protected System.Web.UI.WebControls.CheckBox chkProtected;
 	
 	protected System.Web.UI.WebControls.Button cmdSave;
 	

--- a/MonkeyWrench.Web.UI/ViewLane.aspx.cs
+++ b/MonkeyWrench.Web.UI/ViewLane.aspx.cs
@@ -257,8 +257,12 @@ public partial class ViewLane : System.Web.UI.Page
 				if (response.RevisionWork.State == DBState.NotDone)
 					header.AppendFormat (" - <a href='ViewLane.aspx?lane_id={0}&amp;host_id={2}&amp;revision_id={1}&amp;action=ignorerevision'>don't build</a>", lane.id, dbr.id, host.id);
 				if (response.RevisionWork.State != DBState.NoWorkYet) {
-					GenerateActionLink(header, lane, host, dbr, "clearrevision", "clear", "reset work", hidden);
-					GenerateActionLink(header, lane, host, dbr, "deleterevision", "delete", "delete work", hidden);
+					if (revisionwork.is_protected && response.RevisionWork.State != DBState.Failed) {
+						header.AppendFormat (" - {0}", MonkeyWrench.Configuration.ProtectedMessage);
+					} else {
+						GenerateActionLink (header, lane, host, dbr, "clearrevision", "clear", "reset work", hidden);
+						GenerateActionLink (header, lane, host, dbr, "deleterevision", "delete", "delete work", hidden);
+					}
 				}
 			}
 		}

--- a/MonkeyWrench.Web.WebService/Scheduler/Scheduler.cs
+++ b/MonkeyWrench.Web.WebService/Scheduler/Scheduler.cs
@@ -193,8 +193,8 @@ namespace MonkeyWrench.Scheduler
 
 			try {
 				using (var cmd = db.CreateCommand (@"
-					INSERT INTO RevisionWork (lane_id, host_id, revision_id, priority, state)
-					SELECT Lane.id, Host.id, Revision.id, Lane.priority, 10
+					INSERT INTO RevisionWork (lane_id, host_id, revision_id, priority, is_protected, state)
+					SELECT Lane.id, Host.id, Revision.id, Lane.priority, Lane.is_protected, 10
 					FROM HostLane
 					INNER JOIN Host ON HostLane.host_id = Host.id
 					INNER JOIN Lane ON HostLane.lane_id = Lane.id
@@ -266,8 +266,8 @@ namespace MonkeyWrench.Scheduler
 				}
 				foreach (var id in selected_lanes.Keys) {
 					using (var cmd = db.CreateCommand (string.Format (@"
-						INSERT INTO RevisionWork (lane_id, host_id, revision_id, priority, state)
-						SELECT Lane.id, Host.id, Revision.id, Lane.priority, 10
+						INSERT INTO RevisionWork (lane_id, host_id, revision_id, priority, is_protected, state)
+						SELECT Lane.id, Host.id, Revision.id, Lane.priority, Lane.is_protected, 10
 						FROM HostLane
 						INNER JOIN Host ON HostLane.host_id = Host.id
 						INNER JOIN Lane ON HostLane.lane_id = Lane.id

--- a/MonkeyWrench/Configuration.cs
+++ b/MonkeyWrench/Configuration.cs
@@ -56,6 +56,7 @@ namespace MonkeyWrench
 		public static bool AllowAnonymousAccess = true;
 		public static int NoOutputTimeout = 30; // timeout after this many minutes of no output.
 		public static int NoProgressTimeout = 60; // timeout after this many minutes if the test thread(s) don't seem to be progressing.
+		public static string ProtectedMessage = "This build is protected";
 
 		// oauth
 		public static string OauthClientId = null;
@@ -251,6 +252,7 @@ namespace MonkeyWrench
 				AutomaticScheduler = Boolean.Parse (xml.SelectSingleNode ("MonkeyWrench/Configuration/AutomaticScheduler").GetNodeValue (AutomaticScheduler.ToString ()));
 				AutomaticSchedulerInterval = int.Parse (xml.SelectSingleNode ("MonkeyWrench/Configuration/AutomaticSchedulerInterval").GetNodeValue (AutomaticSchedulerInterval.ToString ()));
 				AllowPasswordLogin = bool.Parse (xml.SelectSingleNode ("MonkeyWrench/Configuration/AllowPasswordLogin").GetNodeValue (AllowPasswordLogin.ToString ()));
+				ProtectedMessage = xml.SelectSingleNode ("MonkeyWrench/Configuration/ProtectedMessage").GetNodeValue (ProtectedMessage);
 
 				OauthClientId = xml.SelectSingleNode ("MonkeyWrench/Configuration/OauthClientId").GetNodeValue (OauthClientId);
 				OauthClientSecret = xml.SelectSingleNode ("MonkeyWrench/Configuration/OauthClientSecret").GetNodeValue (OauthClientSecret);

--- a/scripts/database.sql
+++ b/scripts/database.sql
@@ -84,6 +84,7 @@ CREATE TABLE Lane (
 	  -- * 0: PR lanes, least priority
 	  -- * 1: Unremarkable lanes
 	  -- * 2: Release lanes, highest priority
+	is_protected   boolean    NOT NULL DEFAULT FALSE, -- protection from people resetting builds
 	UNIQUE (lane)
 );
 INSERT INTO Lane (lane, source_control, repository) VALUES ('monkeywrench', 'git', 'git://github.com/mono/monkeywrench');
@@ -92,6 +93,7 @@ INSERT INTO Lane (lane, source_control, repository) VALUES ('monkeywrench', 'git
 -- ALTER TABLE Lane ADD COLUMN changed_date timestamp NULL DEFAULT NULL;
 -- ALTER TABLE Lane ADD CONSTRAINT parentlane_fkey FOREIGN KEY (parent_lane_id) REFERENCES Lane (id);
 -- ALTER TABLE Lane ADD COLUMN priority integer DEFAULT 1 CHECK (priority >= 0), ALTER COLUMN priority SET NOT NULL;
+-- ALTER TABLE Lane ADD COLUMN is_protected boolean DEFAULT FALSE, ALTER COLUMN is_protected SET NOT NULL;
 
 -- Command to set the latest changed_date on every lane.
 -- UPDATE Lane SET changed_date = (SELECT MAX(endtime) FROM RevisionWork WHERE RevisionWork.lane_id = Lane.id);
@@ -261,6 +263,7 @@ CREATE TABLE RevisionWork (
 	startedtime  timestamptz NULL,               -- Time that the first work was created, denormalized from `MIN(work.starttime) WHERE work.revisionwork_id = id`
 	endtime      timestamptz NULL,               -- Time that the RevisionWork was completed
 	priority     int         NOT NULL DEFAULT 1 CHECK (priority >= 0),
+	is_protected boolean     NOT NULL DEFAULT FALSE,
 	
 	-- alter table revisionwork add column endtime        timestamp  NOT NULL DEFAULT '2000-01-01 00:00:00+0';
 	
@@ -308,6 +311,7 @@ CREATE INDEX RevisionWork_state_idx ON RevisionWork (state);
 -- alter table RevisionWork add constraint revisionwork_workhost_id_fkey foreign key (workhost_id) references host (id) on delete cascade;
 -- alter table RevisionWork drop constraint revisionwork_workhost_id_fkey2;
 -- ALTER TABLE revisionwork ADD COLUMN priority integer DEFAULT 1 CHECK (priority >= 0), ALTER COLUMN priority SET NOT NULL;
+-- ALTER TABLE revisionwork ADD COLUMN is_protected boolean DEFAULT FALSE, ALTER COLUMN is_protected SET NOT NULL;
 
 CREATE TABLE Work (
 	id               serial    PRIMARY KEY,


### PR DESCRIPTION
This adds in a protected flag for all RevisionWork items in a Lane. Any build that finishes without error can not be reset (this includes builds with issues). There are some products that we ship even if there are test issues (like MonoDroid, e.g.), which is why they are included in this.

The RevisionWork will inherit the default protected value from the lane it belongs to. A quick SQL query can be made to switch the value if need be, though I could add in a UI element to do this if needed.

No builds will be retroactively set to protected; this is only a change for new builds going forward.