### PR TITLE
Faster responsiveness

### DIFF
--- a/MonkeyWrench.DataClasses/Database/DBLane.generated.cs
+++ b/MonkeyWrench.DataClasses/Database/DBLane.generated.cs
@@ -31,6 +31,7 @@ namespace MonkeyWrench.DataClasses
 		private string _additional_roles;
 		private int _priority;
 		private bool _is_protected;
+		private int _max_commits_to_fetch;
 
 		public string @lane { get { return _lane; } set { _lane = value; } }
 		public string @source_control { get { return _source_control; } set { _source_control = value; } }
@@ -45,6 +46,7 @@ namespace MonkeyWrench.DataClasses
 		public string @additional_roles { get { return _additional_roles; } set { _additional_roles = value; } }
 		public int @priority { get { return _priority; } set { _priority = value; } }
 		public bool @is_protected { get { return _is_protected; } set { _is_protected = value; } }
+		public int @max_commits_to_fetch { get { return _max_commits_to_fetch; } set { _max_commits_to_fetch = value; } }
 
 
 		public override string Table
@@ -57,7 +59,7 @@ namespace MonkeyWrench.DataClasses
 		{
 			get
 			{
-				return new string [] { "lane", "source_control", "repository", "min_revision", "max_revision", "parent_lane_id", "commit_filter", "traverse_merge", "enabled", "changed_date", "additional_roles", "priority", "is_protected" };
+				return new string [] { "lane", "source_control", "repository", "min_revision", "max_revision", "parent_lane_id", "commit_filter", "traverse_merge", "enabled", "changed_date", "additional_roles", "priority", "is_protected", "max_commits_to_fetch" };
 			}
 		}
         

--- a/MonkeyWrench.Database/DB.cs
+++ b/MonkeyWrench.Database/DB.cs
@@ -456,7 +456,7 @@ namespace MonkeyWrench
 					result.source_control = master.source_control;
 					result.parent_lane_id = master.parent_lane_id;
 					result.additional_roles = master.additional_roles;
-					result.enabled = master.enabled;
+					result.enabled = false;
 					result.priority = 1;
 					result.is_protected = master.is_protected;
 					result.max_commits_to_fetch = master.max_commits_to_fetch;

--- a/MonkeyWrench.Database/DB.cs
+++ b/MonkeyWrench.Database/DB.cs
@@ -459,6 +459,7 @@ namespace MonkeyWrench
 					result.enabled = master.enabled;
 					result.priority = 1;
 					result.is_protected = master.is_protected;
+					result.max_commits_to_fetch = master.max_commits_to_fetch;
 					result.Save (this);
 
 					foreach (DBLanefile filemaster in master.GetFiles (this, null)) {
@@ -499,7 +500,7 @@ namespace MonkeyWrench
 
 					foreach (DBHostLaneView hostlanemaster in master.GetHosts (this)) {
 						DBHostLane clone = new DBHostLane ();
-						clone.enabled = false;
+						clone.enabled = hostlanemaster.enabled;
 						clone.lane_id = result.id;
 						clone.host_id = hostlanemaster.host_id;
 						clone.Save (this);

--- a/MonkeyWrench.Web.UI/EditLane.aspx
+++ b/MonkeyWrench.Web.UI/EditLane.aspx
@@ -58,6 +58,12 @@
                 <asp:TableCell>Comma-separated list of additional roles (besides admin) that can edit this lane.</asp:TableCell>
             </asp:TableRow>
             <asp:TableRow>
+                <asp:TableCell>Max Commits to Fetch Per Push</asp:TableCell>
+                <asp:TableCell>
+                    <asp:TextBox id="txtFetchCommits" runat="server" Width="200px" OnKeyPress="return event.which == 8 || (event.which >= 48 && event.which <= 57);"></asp:TextBox>
+                </asp:TableCell>
+            </asp:TableRow>
+            <asp:TableRow>
                 <asp:TableCell>Priority:</asp:TableCell>
                 <asp:TableCell>
                     <asp:DropDownList ID="lstPriority" runat="server" Width="600px">

--- a/MonkeyWrench.Web.UI/EditLane.aspx
+++ b/MonkeyWrench.Web.UI/EditLane.aspx
@@ -60,7 +60,7 @@
             <asp:TableRow>
                 <asp:TableCell>Max Commits to Fetch Per Push</asp:TableCell>
                 <asp:TableCell>
-                    <asp:TextBox id="txtFetchCommits" runat="server" Width="200px" OnKeyPress="return event.which == 8 || (event.which >= 48 && event.which <= 57);"></asp:TextBox>
+                    <asp:TextBox id="txtFetchCommits" runat="server" Width="200px" OnKeyPress="return event.which == 8 || (event.which >= 48 &amp;&amp; event.which &lt;= 57);"></asp:TextBox>
                 </asp:TableCell>
             </asp:TableRow>
             <asp:TableRow>

--- a/MonkeyWrench.Web.UI/EditLane.aspx.cs
+++ b/MonkeyWrench.Web.UI/EditLane.aspx.cs
@@ -709,13 +709,8 @@ public partial class EditLane : System.Web.UI.Page
 		lane.is_protected = chkProtected.Checked;
 
 		// Don't ever pull more than 100 commits
-		try {
-			int commits = Int32.Parse (txtFetchCommits.Text);
-			lane.max_commits_to_fetch = commits >= 100 ? 100 : commits;
-		} catch (OverflowException ex) {
-			lane.max_commits_to_fetch = 1;
-		}
-
+		int commits = Int32.Parse (txtFetchCommits.Text);
+		lane.max_commits_to_fetch = commits >= 100 ? 100 : commits;
 
 		Utils.LocalWebService.EditLaneWithTags (Master.WebServiceLogin, lane, !string.IsNullOrEmpty (txtTags.Text) ? txtTags.Text.Split (',') : null);
 		RedirectToSelf ();

--- a/MonkeyWrench.Web.UI/EditLane.aspx.cs
+++ b/MonkeyWrench.Web.UI/EditLane.aspx.cs
@@ -104,6 +104,7 @@ public partial class EditLane : System.Web.UI.Page
 				txtTags.Text = string.Join (",", response.Tags.ConvertAll<string> ((DBLaneTag tag) => tag.tag).ToArray ());
 			if (response.Lane.additional_roles != null)
 				txtRoles.Text = response.Lane.additional_roles;
+			txtFetchCommits.Text = String.Format("{0}", lane.max_commits_to_fetch);
 			txtLane.Text = lane.lane;
 			txtID.Text = lane.id.ToString ();
 			// find (direct) child lanes
@@ -706,6 +707,15 @@ public partial class EditLane : System.Web.UI.Page
 		lane.additional_roles = txtRoles.Text;
 		lane.priority = Int32.Parse (lstPriority.SelectedItem.Value);
 		lane.is_protected = chkProtected.Checked;
+
+		// Don't ever pull more than 100 commits
+		try {
+			int commits = Int32.Parse (txtFetchCommits.Text);
+			lane.max_commits_to_fetch = commits >= 100 ? 100 : commits;
+		} catch (OverflowException ex) {
+			lane.max_commits_to_fetch = 1;
+		}
+
 
 		Utils.LocalWebService.EditLaneWithTags (Master.WebServiceLogin, lane, !string.IsNullOrEmpty (txtTags.Text) ? txtTags.Text.Split (',') : null);
 		RedirectToSelf ();

--- a/MonkeyWrench.Web.UI/EditLane.aspx.designer.cs
+++ b/MonkeyWrench.Web.UI/EditLane.aspx.designer.cs
@@ -34,6 +34,8 @@ public partial class EditLane {
 	
 	protected System.Web.UI.WebControls.TextBox txtRoles;
 
+	protected System.Web.UI.WebControls.TextBox txtFetchCommits;
+
 	protected System.Web.UI.WebControls.DropDownList lstPriority;
 	
 	protected System.Web.UI.WebControls.DropDownList lstParentLane;

--- a/MonkeyWrench.Web.UI/ViewLane.aspx.cs
+++ b/MonkeyWrench.Web.UI/ViewLane.aspx.cs
@@ -257,7 +257,7 @@ public partial class ViewLane : System.Web.UI.Page
 				if (response.RevisionWork.State == DBState.NotDone)
 					header.AppendFormat (" - <a href='ViewLane.aspx?lane_id={0}&amp;host_id={2}&amp;revision_id={1}&amp;action=ignorerevision'>don't build</a>", lane.id, dbr.id, host.id);
 				if (response.RevisionWork.State != DBState.NoWorkYet) {
-					if (revisionwork.is_protected && response.RevisionWork.State != DBState.Failed) {
+					if (revisionwork.is_protected && (response.RevisionWork.State == DBState.Success || response.RevisionWork.State == DBState.Issues)) {
 						header.AppendFormat (" - {0}", MonkeyWrench.Configuration.ProtectedMessage);
 					} else {
 						GenerateActionLink (header, lane, host, dbr, "clearrevision", "clear", "reset work", hidden);

--- a/MonkeyWrench.Web.WebService/Scheduler/Scheduler.cs
+++ b/MonkeyWrench.Web.WebService/Scheduler/Scheduler.cs
@@ -130,11 +130,6 @@ namespace MonkeyWrench.Scheduler
 					// SVNUpdater svn_updater = null;
 
 					foreach (DBLane lane in lanes) {
-						if (!lane.enabled) {
-							log.InfoFormat ("Schedule: lane {0} is disabled, skipping it.", lane.lane);
-							continue;
-						}
-
 						SchedulerBase updater;
 						switch (lane.source_control) {
 							/*

--- a/MonkeyWrench.Web.WebService/Scheduler/Scheduler.cs
+++ b/MonkeyWrench.Web.WebService/Scheduler/Scheduler.cs
@@ -120,7 +120,7 @@ namespace MonkeyWrench.Scheduler
 				reports = GetReports (forcefullupdate);
 
 				using (DB db = new DB (true)) {
-					lanes = db.GetAllLanes ();
+					lanes = db.GetAllLanes ().FindAll(lane => lane.enabled);
 					hosts = db.GetHosts ();
 					hostlanes = db.GetAllHostLanes ();
 

--- a/MonkeyWrench.Web.WebService/Scheduler/SchedulerGIT.cs
+++ b/MonkeyWrench.Web.WebService/Scheduler/SchedulerGIT.cs
@@ -379,7 +379,7 @@ namespace MonkeyWrench.Scheduler
 					DateTime git_start = DateTime.Now;
 					git.StartInfo.FileName = "git";
 					// --reverse: git normally gives commits in newest -> oldest, we want to add them to the db in the reverse order
-					git.StartInfo.Arguments = "rev-list --reverse --header ";
+					git.StartInfo.Arguments = String.Format("rev-list --reverse --header --max-count={0}", dblane.max_commits_to_fetch);
 					if (!dblane.traverse_merge)
 						git.StartInfo.Arguments += "--first-parent ";
 					git.StartInfo.Arguments += range;

--- a/MonkeyWrench.Web.WebService/WebServices.asmx.cs
+++ b/MonkeyWrench.Web.WebService/WebServices.asmx.cs
@@ -1925,6 +1925,7 @@ WHERE hidden = false AND Lane.enabled = TRUE";
 				DBLane dblane = new DBLane ();
 				dblane.lane = lane;
 				dblane.priority = 1;
+				dblane.max_commits_to_fetch = 1;
 				dblane.source_control = "svn";
 				dblane.Save (db);
 				return dblane.id;

--- a/scripts/database.sql
+++ b/scripts/database.sql
@@ -85,6 +85,7 @@ CREATE TABLE Lane (
 	  -- * 1: Unremarkable lanes
 	  -- * 2: Release lanes, highest priority
 	is_protected   boolean    NOT NULL DEFAULT FALSE, -- protection from people resetting builds
+  max_commits_to_fetch int  NOT NULL DEFAULT 1 CHECK (max_commits_to_fetch >= 1)
 	UNIQUE (lane)
 );
 INSERT INTO Lane (lane, source_control, repository) VALUES ('monkeywrench', 'git', 'git://github.com/mono/monkeywrench');
@@ -94,6 +95,7 @@ INSERT INTO Lane (lane, source_control, repository) VALUES ('monkeywrench', 'git
 -- ALTER TABLE Lane ADD CONSTRAINT parentlane_fkey FOREIGN KEY (parent_lane_id) REFERENCES Lane (id);
 -- ALTER TABLE Lane ADD COLUMN priority integer DEFAULT 1 CHECK (priority >= 0), ALTER COLUMN priority SET NOT NULL;
 -- ALTER TABLE Lane ADD COLUMN is_protected boolean DEFAULT FALSE, ALTER COLUMN is_protected SET NOT NULL;
+-- ALTER TABLE Lane ADD COLUMN max_commits_to_fetch int DEFAULT 1 CHECK (max_commits_to_fetch >= 1), ALTER COLUMN is_protected SET NOT NULL;
 
 -- Command to set the latest changed_date on every lane.
 -- UPDATE Lane SET changed_date = (SELECT MAX(endtime) FROM RevisionWork WHERE RevisionWork.lane_id = Lane.id);


### PR DESCRIPTION
Primarily, this PR contains work to add in a new field for Lanes which specify how far back in the commit history to go when creating new builds after someone pushes. Unless changed, the default value set will cause Wrench to only pull the last commit.

Additionally, contains a few minor tweaks:
1) prevents the scheduler from querying lanes that have been disabled
2) causes cloned lanes to enable the same hosts as the master lane (less manual work)
3) fixes a bug where the protected lanes caused unfinished builds from being reset