### PR TITLE
Top only builds

### DIFF
--- a/MonkeyWrench.Web.WebService/Scheduler/Scheduler.cs
+++ b/MonkeyWrench.Web.WebService/Scheduler/Scheduler.cs
@@ -381,12 +381,7 @@ namespace MonkeyWrench.Scheduler
 								fetched_dependencies = true;
 							}
 
-							has_dependencies = dependencies != null && dependencies.Any (dep => dep.lane_id == lane.id);
-
-							log.DebugFormat ("AddWork: Lane '{0}', revisionwork_id '{1}' has dependencies: {2}", lane.lane, revisionwork.id, has_dependencies);
-
 							foreach (DBCommand command in commands_in_lane) {
-								int work_state = (int) (has_dependencies ? DBState.DependencyNotFulfilled : DBState.NotDone);
 
 								sql.AppendFormat ("INSERT INTO Work (command_id, revisionwork_id, state) VALUES ({0}, {1}, 11);\n", command.id, revisionwork.id);
 								lines++;
@@ -402,40 +397,65 @@ namespace MonkeyWrench.Scheduler
 							}
 
 							sql.AppendFormat ("UPDATE RevisionWork SET state = 11 WHERE id = {0} AND state = 10;", revisionwork.id);
+							lines++;
 							if (!editedHostLanes.Contains (hostlane)) editedHostLanes.Add (hostlane);
 						}
 					}
 				}
 
-				foreach (var editedHostLane in editedHostLanes) {
-					int mostRecent = -1;
-					int mostRecentState = -1;
+				if (editedHostLanes.Count > 0) {
 					using (IDbCommand cmd = db.CreateCommand ()) {
+						bool first = true;
+						int revisionwork_id;
+						int lane_id;
+						int state;
+
 						cmd.CommandText = @"
-SELECT RevisionWork.id, RevisionWork.state
+SELECT RevisionWork.id, RevisionWork.lane_id
 FROM RevisionWork
 INNER JOIN Revision ON Revision.id = RevisionWork.revision_id
-WHERE
-     RevisionWork.host_id = @host_id
- AND RevisionWork.lane_id = @lane_id
-ORDER BY Revision.Date DESC
-LIMIT 1
+INNER JOIN (
+	SELECT a.lane_id, a.date, a.id
+	FROM Revision a
+	INNER JOIN (
+		SELECT lane_id, MAX (date) DATE
+		FROM Revision
+		GROUP BY lane_id
+	) b ON a.lane_id = b.lane_id AND a.date = b.date
+	INNER JOIN Lane ON Lane.id = a.lane_id
+	WHERE Lane.enabled = TRUE
+		AND (
 ";
-						DB.CreateParameter (cmd, "host_id", editedHostLane.host_id);
-						DB.CreateParameter (cmd, "lane_id", editedHostLane.lane_id);
-						using (IDataReader reader = cmd.ExecuteReader ()) {
-							if (reader.Read ()) {
-								mostRecent = reader.GetInt32 (0);
-								mostRecentState = reader.GetInt32 (1);;
+
+						foreach (var editedHostLane in editedHostLanes) {
+							if (first) {
+								cmd.CommandText += String.Format ("Lane.id = {0}", editedHostLane.lane_id);
+								first = false;
+							} else {
+								cmd.CommandText += String.Format ("OR Lane.id = {0}", editedHostLane.lane_id);
 							}
 						}
-					}
+						cmd.CommandText += ")) LATEST ON RevisionWork.lane_id = latest.lane_id AND RevisionWork.revision_id = latest.id";
 
-					if (mostRecent >= 0 && mostRecentState == (int)DBState.NoWorkYet) {
-						// Don't need to fetch deps here because they should already have been fetched in previous loop
-						has_dependencies = dependencies != null && dependencies.Any (dep => dep.lane_id == editedHostLane.lane_id);
-						sql.AppendFormat ("UPDATE Revisionwork SET state = {0} where id = {1};", (int)(has_dependencies ? DBState.DependencyNotFulfilled : DBState.NotDone), mostRecent);
-						sql.AppendFormat ("UPDATE Work SET state = {0} where revisionwork_id = {1};", (int)(has_dependencies? DBState.DependencyNotFulfilled : DBState.NotDone), mostRecent);
+						using (IDataReader reader = cmd.ExecuteReader ()) {
+							while (reader.Read ()) {
+								if ((lines % 100) == 0 || (lines % 101) == 0) {
+									db.ExecuteNonQuery (sql.ToString ());
+									sql.Clear ();
+									log.DebugFormat ("AddWork: flushed work queue, added {0} items now.", lines);
+								}
+								revisionwork_id = reader.GetInt32 (0);
+								lane_id = reader.GetInt32 (1);
+
+								has_dependencies = dependencies != null && dependencies.Any (dep => dep.lane_id == lane_id);
+								state = (int)(has_dependencies ? DBState.DependencyNotFulfilled : DBState.NotDone);
+								log.DebugFormat ("AddWork: Lane '{0}', revisionwork_id '{1}' has dependencies: {2}", lane_id, revisionwork_id, has_dependencies);
+
+								sql.AppendFormat ("UPDATE Revisionwork SET state = {0} WHERE id = {1} AND state = 11;", state, revisionwork_id);
+								sql.AppendFormat ("UPDATE Work SET state = {0} WHERE revisionwork_id = {1} AND state = 11;", state, revisionwork_id);
+								lines += 2;
+							}
+						}
 					}
 				}
 

--- a/scripts/database.sql
+++ b/scripts/database.sql
@@ -85,7 +85,7 @@ CREATE TABLE Lane (
 	  -- * 1: Unremarkable lanes
 	  -- * 2: Release lanes, highest priority
 	is_protected   boolean    NOT NULL DEFAULT FALSE, -- protection from people resetting builds
-  max_commits_to_fetch int  NOT NULL DEFAULT 1 CHECK (max_commits_to_fetch >= 1)
+  max_commits_to_fetch int  NOT NULL DEFAULT 100 CHECK (max_commits_to_fetch >= 1)
 	UNIQUE (lane)
 );
 INSERT INTO Lane (lane, source_control, repository) VALUES ('monkeywrench', 'git', 'git://github.com/mono/monkeywrench');


### PR DESCRIPTION
Explicitly mark all builds that aren't at the head of the tree when the scheduler runs as "Do not build" when populating the hostlane with new revisionworks.

I think this will (unfortunately) mess with the "delete build" button in that any build reset this way will be marked as ignored.