### PR TITLE
Use method of getting hresult from older .net version

### DIFF
--- a/MonkeyWrench.Builder/Builder.cs
+++ b/MonkeyWrench.Builder/Builder.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Text;
 using log4net;
-
+using System.Runtime.InteropServices;
 using MonkeyWrench;
 using MonkeyWrench.DataClasses;
 using MonkeyWrench.DataClasses.Logic;
@@ -120,9 +120,9 @@ namespace MonkeyWrench.Builder
 		{
 			const int HR_ERROR_HANDLE_DISK_FULL = unchecked((int)0x80070027);
 			const int HR_ERROR_DISK_FULL = unchecked((int)0x80070070);
-
-			return ex.HResult == HR_ERROR_HANDLE_DISK_FULL
-				|| ex.HResult == HR_ERROR_DISK_FULL;
+			int hr = Marshal.GetHRForException(ex);
+			return hr == HR_ERROR_HANDLE_DISK_FULL
+				|| hr == HR_ERROR_DISK_FULL;
 		}
 
 		private static bool Update (BuildBotStatus status, ReportBuildBotStatusResponse status_response)


### PR DESCRIPTION
https://stackoverflow.com/questions/991537/how-do-i-determine-the-hresult-for-a-system-io-ioexception

It says Exception.HResult is public now, but I get this when I try to build 
error CS1540: Cannot access protected member `System.Exception.HResult' via a qualifier of type `System.Exception'. The qualifier must be of type `MonkeyWrench.Builder.Builder' or derived from it

I assumed that if the change happened in .net 4.5 it would work, but when I use xbuild or the new msbuild from VS for mac I get this error. Not sure what the approach should be, but using Marshal.GetHRForException() works.